### PR TITLE
Setup ci and scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 envs/
 __pycache__/
 *.egg-info/
+.idea/

--- a/app/api/deps.py
+++ b/app/api/deps.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 
 # TODO: JWT 인증 로직이 생기면 여기서 current user dependency를 제공
-def get_current_user():
+def get_current_user() -> None:
     """현재 로그인 유저를 반환하는 Depends 자리.
 
     구현 예:

--- a/app/api/router.py
+++ b/app/api/router.py
@@ -12,13 +12,13 @@
 
 from fastapi import APIRouter
 
-from app.domains.auth.router import router as auth_router
-from app.domains.users.router import router as users_router
-from app.domains.categories.router import router as categories_router
 from app.domains.artists.router import router as artists_router
-from app.domains.streams.router import router as streams_router
+from app.domains.auth.router import router as auth_router
+from app.domains.categories.router import router as categories_router
 from app.domains.chat.router_ws import router as chat_router
 from app.domains.notifications.router import router as notifications_router
+from app.domains.streams.router import router as streams_router
+from app.domains.users.router import router as users_router
 
 api_router = APIRouter(prefix="/api/v1")
 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -36,4 +36,4 @@ class Settings(BaseSettings):
         )
 
 
-settings = Settings()  # type: ignore[call-arg]
+settings = Settings()

--- a/app/domains/auth/__init__.py
+++ b/app/domains/auth/__init__.py
@@ -1,4 +1,5 @@
 """
 app/domains/auth/
-- 소셜 로그인/회원가입(카카오/네이버) 도메인. 외부 OAuth는 integrations/*를 호출하고, 우리 서비스 User upsert 및 JWT 발급을 수행.
+- 소셜 로그인/회원가입(카카오/네이버) 도메인.
+- 외부 OAuth는 integrations/*를 호출하고, 우리 서비스 User upsert 및 JWT 발급을 수행.
 """

--- a/app/main.py
+++ b/app/main.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import logging
 from contextlib import asynccontextmanager
+from typing import AsyncIterator
 
 from fastapi import FastAPI
 from tortoise import Tortoise
@@ -25,7 +26,7 @@ logger = logging.getLogger("app")
 
 
 @asynccontextmanager
-async def lifespan(app: FastAPI):
+async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     """서버 시작/종료 훅.
 
     startup(위쪽):
@@ -49,7 +50,7 @@ app.include_router(api_router)
 
 
 @app.get("/health")
-async def health():
+async def health() -> dict[str, bool]:
     """기본 헬스체크.
 
     여기에 넣을 것:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,8 @@ dev = [
     "httpx>=0.28.1",
     "mypy>=1.19.1",
     "pytest>=9.0.2",
+    "pytest-asyncio>=0.23.0",
+    "pytest-dotenv>=0.5.2",
     "ruff>=0.14.10",
 ]
 
@@ -35,17 +37,38 @@ tortoise_orm = "app.core.tortoise_config.TORTOISE_ORM"
 location = "./migrations"
 src_folder = "./."
 
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]
+asyncio_default_fixture_loop_scope = "session"
+env_files = ["envs/.local.env"]
+
 [tool.ruff]
+target-version = "py313"
+line-length = 100
 cache-dir = ".cache/ruff"
 
+[tool.ruff.lint]
+select = ["E", "F", "I", "B"]
+
 [tool.mypy]
+plugins = ["pydantic.mypy"]
+python_version = 3.13
+strict = true
+ignore_missing_imports = true
 cache_dir = ".cache/mypy"
 
 [tool.coverage.run]
 data_file = ".cache/coverage/.coverage"
+source = ["app"]
+omit = ["*/test_*.py"]
 
 [tool.coverage.html]
 directory = ".cache/coverage/html"
 
 [tool.coverage.xml]
 output = ".cache/coverage/coverage.xml"
+
+[tool.coverage.report]
+show_missing = true
+skip_covered = true

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+printf "\n🎨  Running Ruff Format..."
+uv run ruff format .
+
+printf "\n🔍  Running Ruff Lint (Fixing auto-fixable issues)...\n"
+uv run ruff check . --fix
+
+printf "\n🛡️  Running Mypy (Type Check)...\n"
+uv run mypy .
+
+printf "\n✅  Check Complete!"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# 에러 발생 시 즉시 중단
+set -e
+
+printf "\n🧪  Running Pytest with Coverage...\n\n"
+uv run coverage run -m pytest
+
+printf "\n📊  Generating Coverage Report...\n\n"
+
+# 80% 미만일 경우 경고
+uv run coverage report --fail-under=80
+
+printf "\n ✅  Test and Coverage Complete!"

--- a/uv.lock
+++ b/uv.lock
@@ -706,6 +706,8 @@ dev = [
     { name = "httpx" },
     { name = "mypy" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-dotenv" },
     { name = "ruff" },
 ]
 
@@ -726,6 +728,8 @@ dev = [
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "mypy", specifier = ">=1.19.1" },
     { name = "pytest", specifier = ">=9.0.2" },
+    { name = "pytest-asyncio", specifier = ">=0.23.0" },
+    { name = "pytest-dotenv", specifier = ">=0.5.2" },
     { name = "ruff", specifier = ">=0.14.10" },
 ]
 
@@ -861,6 +865,32 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
+name = "pytest-dotenv"
+version = "0.5.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "python-dotenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cd/b0/cafee9c627c1bae228eb07c9977f679b3a7cb111b488307ab9594ba9e4da/pytest-dotenv-0.5.2.tar.gz", hash = "sha256:2dc6c3ac6d8764c71c6d2804e902d0ff810fa19692e95fe138aefc9b1aa73732", size = 3782, upload-time = "2020-06-16T12:38:03.4Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/da/9da67c67b3d0963160e3d2cbc7c38b6fae342670cc8e6d5936644b2cf944/pytest_dotenv-0.5.2-py3-none-any.whl", hash = "sha256:40a2cece120a213898afaa5407673f6bd924b1fa7eafce6bda0e8abffe2f710f", size = 3993, upload-time = "2020-06-16T12:38:01.139Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## ✅ PR 한줄 요약
- CI 대응 scripts 작성 및 ruff, mypy, pytest, coverage 설정 변경

## 🔗 관련 이슈
- 없음

## 🛠️ 변경 내용
- pytest-asyncio 설정 및 dotenv 사용
- ruff 
  - ruff line-length 100으로 수정
  - ruff target version 설정 (py 3.13)
  - ruff error 추가
- mypy strict 모드로 변경 (강한 검사)
- coverage
  - coverage source app으로 지정
  - coverage 대상 파일 */test_*.py로 지정
  - coverage show_missing 설정
  - coverage cover 100%인 파일 skip
  - coverage 80 미만 경고

## 🧪 테스트
- 로컬에서 sh 두 개 다 돌려봄
- `chmod +x scripts/check.sh scripts/test.sh` 하고 쓰슈
