### PR TITLE
Chore: ECR 인증 방식을 IAM Role 기반으로 변경하여 보안 강화

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -46,7 +46,6 @@ jobs:
           key: ${{ secrets.EC2_SSH_KEY }}
           script: |
             export PATH=$PATH:/usr/local/bin
-            aws ecr get-login-password --region ap-northeast-2 | sudo docker login --username AWS --password-stdin ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.ap-northeast-2.amazonaws.com
             
             cd ~/app
             docker compose -f docker-compose.dev.yml pull


### PR DESCRIPTION
- SSH 배포 스크립트에서 불필요한 docker login 명령어 제거
- EC2에 설정된 IAM 역할을 사용하도록 하여 비밀번호 노출 위험 제거
- GitHub Actions의 Docker credentials 관련 보안 경고 해결

## ✅ PR 한줄 요약
- [aws-ecr-login 깃헙](https://github.com/aws-actions/amazon-ecr-login#docker-credentials) 참고해서 best practice로 변경


## 🛠️ 변경 내용
- [x] ec2 cli에서 `sudo yum install -y amazon-ecr-credential-helper`
- [x] ~/.docker/config.json에 role 추가
  - [x] `"credsStore": "ecr-login":` 인증이 필요하면 직접 입력이 아니라 ecr-login 헬퍼 프로그램 대신 처리
  - [x] `"credHelpers": { ... }:` 이 ECR 주소로 접속할 때는 ecr-login 헬퍼 사용하도록 지정
- [x] cd에서 ssh 수정 (불필요한 docker login 명령어 제거)

## 🧪 테스트
- [x] 서버에서 `docker pull 아마존아이디.dkr.ecr.ap-northeast-2.amazonaws.com/near05-api:latest`으로 유효성 확인