### PR TITLE
Near 48 setup broadcast admin

### DIFF
--- a/app/api/router.py
+++ b/app/api/router.py
@@ -17,6 +17,7 @@ from app.domains.auth.router import router as auth_router
 from app.domains.chat.router_ws import router as chat_router
 from app.domains.notifications.router import router as notifications_router
 from app.domains.streams.router import router as streams_router
+from app.domains.streams.router_admin import router as streams_admin_router
 from app.domains.users.router import router as users_router
 
 api_router = APIRouter(prefix="/api/v1")
@@ -26,5 +27,6 @@ api_router.include_router(auth_router)
 api_router.include_router(users_router)
 api_router.include_router(artists_router)
 api_router.include_router(streams_router)
+api_router.include_router(streams_admin_router)
 api_router.include_router(chat_router)
 api_router.include_router(notifications_router)

--- a/app/domains/streams/deps.py
+++ b/app/domains/streams/deps.py
@@ -1,0 +1,17 @@
+from app.domains.streams.service import StreamService
+from app.integrations.aws_ivs import IVSClient, IVSPlaybackProvider
+
+
+def get_ivs_client() -> IVSClient:
+    return IVSClient()
+
+
+def get_playback_provider() -> IVSPlaybackProvider:
+    return IVSPlaybackProvider()
+
+
+def get_streams_service() -> StreamService:
+    return StreamService(
+        ivs_client=get_ivs_client(),
+        playback_provider=get_playback_provider(),
+    )

--- a/app/domains/streams/models.py
+++ b/app/domains/streams/models.py
@@ -103,6 +103,9 @@ class Concert(models.Model):
         description="이 공연에 참여하는 모든 출연진 목록",
     )
 
+    if TYPE_CHECKING:
+        stream_channel: "StreamChannel"  # 역참조
+
     class Meta:
         table = "concerts"
 

--- a/app/domains/streams/permissions.py
+++ b/app/domains/streams/permissions.py
@@ -1,10 +1,33 @@
-"""streams 권한 체크 모듈.
+from fastapi import HTTPException
 
-여기에 넣을 것:
-- 스트리밍 시청 가능 여부(유료/무료, 구매, 권한 등)
-- 어드민만 가능한 작업(생성/수정/삭제) 체크
-- 채팅 참여 가능 여부(시청권한 기반)
+from app.domains.streams.models import AccessLevel, Concert
+from app.domains.users.models import User
 
-구조:
-- router/service에서 if문으로 흩어놓지 말고 여기 함수로 모으기.
-"""
+
+class StreamPermission:
+    @staticmethod
+    def must_be_admin(user: User) -> None:
+        if not user.is_superuser:
+            raise HTTPException(403, "관리자만 접근이 가능합니다.")
+
+    @staticmethod
+    async def verify_playback_access(user: User, concert: Concert) -> None:
+        """
+        유저가 IVS 토큰을 발급받을 자격이 있는지 확인
+        """
+        if user.is_superuser or concert.access_level == AccessLevel.PUBLIC:
+            return
+
+        if concert.access_level == AccessLevel.ADMIN_ONLY:
+            raise HTTPException(403, "테스트 중인 방송입니다.")
+
+        # from app.domains.orders.models import UserTicket
+        if concert.access_level == AccessLevel.SPECIFIC:
+            # TODO: 유료/무료 공연 기능 추가 -> 티켓 구매 여부 확인
+            # has_ticket = await UserTicket.filter(
+            #     user=user, concert=concert, is_valid=True
+            # ).exists()
+            # 지금은 없으니까 그냥 False로 에러 띄움
+            has_ticket = False
+            if not has_ticket:
+                raise HTTPException(402, "티켓 구매가 필요한 공연입니다.")

--- a/app/domains/streams/router.py
+++ b/app/domains/streams/router.py
@@ -1,18 +1,22 @@
-"""streams 도메인 HTTP 라우터.
+from typing import Any
 
-여기에 넣을 것:
-- APIRouter(prefix='...', tags=[...])
-- endpoints 정의(GET/POST/PATCH/DELETE)
-- Depends로 인증/권한 체크
-- service 함수를 호출해서 결과 반환
+from fastapi import APIRouter, Depends
 
-예:
-- GET /streams
-- POST /streams
-"""
+from app.api import deps
+from app.domains.streams import deps as streams_deps
+from app.domains.streams.service import StreamService
+from app.domains.users.models import User
 
-from fastapi import APIRouter
+router = APIRouter(prefix="/streams", tags=["Streaming"])
 
-router = APIRouter(prefix="/streams", tags=["streams"])
 
-# TODO: endpoints 추가
+@router.get("/{concert_id}/credentials", summary="스트림 시청 권한 확인 - 토큰 발급")
+async def get_stream_access(
+    concert_id: int,
+    current_user: User = Depends(deps.get_current_user),
+    service: StreamService = Depends(streams_deps.get_streams_service),
+) -> dict[str, Any]:
+    """
+    해당 콘서트의 시청 자격 검증 -> IVS 재생 토큰 + 채팅용 세션 토큰 반환
+    """
+    return await service.get_viewing_credentials(concert_id, current_user)

--- a/app/domains/streams/router_admin.py
+++ b/app/domains/streams/router_admin.py
@@ -1,0 +1,28 @@
+from fastapi import APIRouter, Depends
+from starlette import status
+
+from app.api import deps
+from app.domains.streams import deps as streams_deps
+from app.domains.streams.models import Concert
+from app.domains.streams.schemas import ConcertCreateRequest, ConcertResponse
+from app.domains.streams.service import StreamService
+from app.domains.users.models import User
+
+router = APIRouter(prefix="/admin/streams", tags=["[Admin] Streaming"])
+
+
+@router.post(
+    "/setup",
+    status_code=status.HTTP_201_CREATED,
+    response_model=ConcertResponse,
+    summary="콘서트 생성 - IVS 채널 자동 설정",
+)
+async def create_concert_stream(
+    data: ConcertCreateRequest,
+    current_user: User = Depends(deps.get_current_user),
+    service: StreamService = Depends(streams_deps.get_streams_service),
+) -> Concert:
+    """
+    관리자 권한으로 신규 콘서트 생성 -> AWS IVS 인프라 할당
+    """
+    return await service.create_concert_and_channel(data, current_user)

--- a/app/domains/streams/schemas.py
+++ b/app/domains/streams/schemas.py
@@ -23,6 +23,9 @@ class ConcertCreateRequest(BaseModel):
     start_at: datetime
     end_at: datetime | None = None
 
+    # 검색/필터링을 위한 아티스트 연결
+    artist_ids: list[int] = Field(default_factory=list, description="출연 아티스트 ID 목록")
+
     # 채널 설정 (기본값 제공)
     channel_config: ChannelConfig = Field(default_factory=ChannelConfig)
 

--- a/app/domains/streams/schemas.py
+++ b/app/domains/streams/schemas.py
@@ -1,9 +1,39 @@
-"""streams 도메인 Pydantic 스키마.
+from datetime import datetime
 
-여기에 넣을 것:
-- Request/Response 모델들
-- 예: CreateRequest, UpdateRequest, ListResponse, DetailResponse
+from pydantic import BaseModel, Field
 
-팁:
-- 외부로 노출되는 응답 스키마는 항상 schemas에 모으는게 추적하기 쉬움.
-"""
+from app.domains.streams.models import AccessLevel, CategoryType, ChannelType, LatencyMode
+
+
+class ChannelConfig(BaseModel):
+    """IVS 채널 생성 상세 설정"""
+
+    latency_mode: LatencyMode = Field(default=LatencyMode.LOW)
+    channel_type: ChannelType = Field(default=ChannelType.STANDARD)
+
+
+class ConcertCreateRequest(BaseModel):
+    """콘서트 생성 요청 스키마"""
+
+    category: CategoryType
+    title: str = Field(..., min_length=1, max_length=100)
+    description: str | None = None
+    thumbnail_url: str | None = None
+    access_level: AccessLevel = Field(default=AccessLevel.PUBLIC)
+    start_at: datetime
+    end_at: datetime | None = None
+
+    # 채널 설정 (기본값 제공)
+    channel_config: ChannelConfig = Field(default_factory=ChannelConfig)
+
+
+class ConcertResponse(BaseModel):
+    """콘서트 생성 완료 응답"""
+
+    id: int
+    title: str
+    access_level: AccessLevel
+    created_at: datetime
+
+    class Config:
+        from_attributes = True

--- a/app/domains/streams/service.py
+++ b/app/domains/streams/service.py
@@ -1,8 +1,6 @@
 from typing import Any
 
-from app.domains.streams.models import ConcertArtist
-
-from app.domains.streams.models import AccessLevel, Concert, StreamChannel
+from app.domains.streams.models import AccessLevel, Concert, ConcertArtist, StreamChannel
 from app.domains.streams.permissions import StreamPermission
 from app.domains.streams.schemas import ConcertCreateRequest
 from app.domains.users.models import User

--- a/app/domains/streams/service.py
+++ b/app/domains/streams/service.py
@@ -1,10 +1,83 @@
-"""streams 도메인 서비스(비즈니스 로직).
+from typing import Any
 
-여기에 넣을 것:
-- router에서 호출할 함수들
-  - create_*, update_*, delete_*, list_*, get_*
-- DB 접근(Tortoise 쿼리) + 검증/권한체크 + 외부연동 호출(integrations)
+from app.domains.streams.models import AccessLevel, Concert, StreamChannel
+from app.domains.streams.permissions import StreamPermission
+from app.domains.streams.schemas import ConcertCreateRequest
+from app.domains.users.models import User
+from app.integrations.aws_ivs import IVSClient, IVSPlaybackProvider
 
-규칙:
-- router.py에는 로직을 최소화하고, 실제 처리는 service로 내려보내기.
-"""
+
+class StreamService:
+    def __init__(self, ivs_client: IVSClient, playback_provider: IVSPlaybackProvider):
+        self.ivs_client = ivs_client
+        self.playback_provider = playback_provider
+
+    async def create_concert_and_channel(self, data: ConcertCreateRequest, user: User) -> Concert:
+        """
+        [Admin] 콘서트 생성 및 AWS IVS 채널 자동 발급
+        """
+        # 권한 체크
+        StreamPermission.must_be_admin(user)
+
+        # Concert 생성
+        # channel_config는 IVS 설정용이므로 DB 모델 생성시에는 제외
+        concert_dict = data.model_dump(exclude={"channel_config"})
+        concert = await Concert.create(**concert_dict)
+
+        # IVS 채널 생성 호출
+        config = data.channel_config
+        is_private = concert.access_level != AccessLevel.PUBLIC  # 비공개
+
+        ivs_res = self.ivs_client.create_channel(
+            name=f"concert_{concert.id}",
+            latency_mode=config.latency_mode.value,
+            channel_type=config.channel_type.value,
+            authorized=is_private,
+        )
+
+        # StreamChannel(IVS 정보) 저장 및 스트림 키 암호화
+        channel = await StreamChannel.create(
+            concert=concert,
+            type=config.channel_type,
+            latency_mode=config.latency_mode,
+            channel_arn=ivs_res["channel"]["arn"],
+            ingest_endpoint=ivs_res["channel"]["ingestEndpoint"],
+            playback_url=ivs_res["channel"]["playbackUrl"],
+            is_private=is_private,
+        )
+
+        # 모델 내부의 Fernet 암호화 로직 호출
+        channel.set_stream_key(ivs_res["streamKey"]["value"])
+        await channel.save()
+
+        return concert
+
+    async def get_viewing_credentials(self, concert_id: int, user: User) -> dict[str, Any]:
+        """
+        [User] 시청 권한 확인 및 재생/채팅 토큰 발급
+        """
+        concert = await Concert.get(id=concert_id).prefetch_related("stream_channel")
+
+        # 유저 권한 증명
+        await StreamPermission.verify_playback_access(user, concert)
+
+        channel: StreamChannel = concert.stream_channel
+        playback_url: str = channel.playback_url
+
+        # 비공개 채널이면 토큰 서명
+        if channel.is_private:
+            token = self.playback_provider.sign_playback_token(
+                channel_arn=channel.channel_arn, viewer_id=str(user.id)
+            )
+            playback_url = f"{playback_url}?token={token}"
+
+        # 내부 세션 토큰
+        internal_tokens = self.playback_provider.sign_internal_tokens(
+            user_id=str(user.id), stream_id=str(concert.id)
+        )
+
+        return {
+            "playback_url": playback_url,
+            "access_token": internal_tokens["access_token"],
+            "refresh_token": internal_tokens["refresh_token"],
+        }

--- a/app/domains/streams/service.py
+++ b/app/domains/streams/service.py
@@ -1,5 +1,7 @@
 from typing import Any
 
+from app.domains.streams.models import ConcertArtist
+
 from app.domains.streams.models import AccessLevel, Concert, StreamChannel
 from app.domains.streams.permissions import StreamPermission
 from app.domains.streams.schemas import ConcertCreateRequest
@@ -21,8 +23,13 @@ class StreamService:
 
         # Concert 생성
         # channel_config는 IVS 설정용이므로 DB 모델 생성시에는 제외
-        concert_dict = data.model_dump(exclude={"channel_config"})
+        concert_dict = data.model_dump(exclude={"channel_config", "artist_ids"})
         concert = await Concert.create(**concert_dict)
+
+        # 아티스트 매핑 생성
+        if data.artist_ids:
+            for artist_id in data.artist_ids:
+                await ConcertArtist.create(concert=concert, artist_id=artist_id)
 
         # IVS 채널 생성 호출
         config = data.channel_config

--- a/app/integrations/aws_ivs/__init__.py
+++ b/app/integrations/aws_ivs/__init__.py
@@ -4,3 +4,11 @@ app/integrations/aws_ivs/
 - client.py: boto3/SDK 래핑 (채널 생성/삭제, 스트림키 등)
 - playback.py: playback token 발급/검증 정책(시청권한/만료/리프레시 등)
 """
+
+from app.integrations.aws_ivs.client import IVSClient
+from app.integrations.aws_ivs.playback import IVSPlaybackProvider
+
+__all__ = [
+    "IVSClient",
+    "IVSPlaybackProvider",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ exclude = [
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "B", "UP", "C4", "SIM", "TCH"]
+ignore = ["B008"]  # FastAPI의 Depends 사용을 위해 추가
 
 [tool.mypy]
 plugins = ["pydantic.mypy"]

--- a/tests/streams/test_permissions.py
+++ b/tests/streams/test_permissions.py
@@ -1,0 +1,50 @@
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from app.domains.streams.models import AccessLevel, Concert
+from app.domains.streams.permissions import StreamPermission
+from app.domains.users.models import User
+
+
+@pytest.mark.asyncio
+async def test_verify_playback_access_public_allows():
+    """PUBLIC 모든 유저"""
+    user = MagicMock(spec=User)
+    user.is_superuser = False
+
+    concert = MagicMock(spec=Concert)
+    concert.access_level = AccessLevel.PUBLIC
+
+    await StreamPermission.verify_playback_access(user, concert)
+
+
+@pytest.mark.asyncio
+async def test_verify_playback_access_admin_only_denied():
+    """ADMIN_ONLY 관리자만 접근 가능"""
+    user = MagicMock(spec=User)
+    user.is_superuser = False
+
+    concert = MagicMock(spec=Concert)
+    concert.access_level = AccessLevel.ADMIN_ONLY
+
+    with pytest.raises(HTTPException) as exc:
+        await StreamPermission.verify_playback_access(user, concert)
+
+    assert exc.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_verify_playback_access_specific_requires_ticket():
+    """SPECIFIC 티켓(권한) 있어야 접근 가능"""
+    user = MagicMock(spec=User)
+    user.is_superuser = False
+
+    concert = MagicMock(spec=Concert)
+    concert.access_level = AccessLevel.SPECIFIC
+
+    with pytest.raises(HTTPException) as exc:
+        await StreamPermission.verify_playback_access(user, concert)
+
+    assert exc.value.status_code == 402

--- a/tests/streams/test_router.py
+++ b/tests/streams/test_router.py
@@ -1,0 +1,123 @@
+from datetime import UTC
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.api import deps
+from app.domains.streams import deps as streams_deps
+from app.domains.streams.models import AccessLevel, CategoryType, ChannelType, Concert, LatencyMode
+from app.domains.streams.schemas import ChannelConfig, ConcertCreateRequest
+from app.domains.streams.service import StreamService
+from app.domains.users.models import User
+from app.main import app
+
+
+# Mock Objects 준비
+@pytest.fixture
+def mock_user() -> User:
+    """테스트용 관리자 유저 객체"""
+    user = MagicMock(spec=User)
+    user.id = 1
+    user.is_superuser = True
+    user.is_active = True
+    return user
+
+
+@pytest.fixture
+def mock_service() -> MagicMock:
+    """비즈니스 로직을 담당하는 StreamsService 모킹"""
+    service = MagicMock(spec=StreamService)
+
+    # 관리자용 방송 생성 리턴값 설정
+    mock_concert = MagicMock(spec=Concert)
+    mock_concert.id = 999
+    mock_concert.title = "테스트 콘서트"
+    mock_concert.access_level = AccessLevel.PUBLIC
+    mock_concert.created_at = "2026-01-20T22:00:00"
+
+    service.create_concert_and_channel = AsyncMock(return_value=mock_concert)
+
+    # 유저용 자격 증명 리턴값 설정
+    service.get_viewing_credentials = AsyncMock(
+        return_value={
+            "playback_url": "https://test.m3u8",
+            "access_token": "mock_access",
+            "refresh_token": "mock_refresh",
+        }
+    )
+    return service
+
+
+@pytest.fixture
+def client(mock_user, mock_service) -> TestClient:
+    """FastAPI 의존성을 교체(Override)한 테스트 클라이언트"""
+    # 실제 인증 및 서비스 생성을 Mock으로 교체
+    app.dependency_overrides[deps.get_current_user] = lambda: mock_user
+    app.dependency_overrides[streams_deps.get_streams_service] = lambda: mock_service
+
+    with TestClient(app) as c:
+        yield c
+
+    # 테스트 종료 후 복구
+    app.dependency_overrides.clear()
+
+
+def test_admin_setup_endpoint(client: TestClient) -> None:
+    """관리자 방송 생성 API 테스트"""
+    from datetime import datetime
+
+    request_obj = ConcertCreateRequest(
+        category=CategoryType.KPOP,
+        title="테스트 콘서트",
+        start_at=datetime(2026, 1, 20, 22, 0, 0, tzinfo=UTC),
+        access_level=AccessLevel.PUBLIC,
+        channel_config=ChannelConfig(
+            latency_mode=LatencyMode.LOW, channel_type=ChannelType.STANDARD
+        ),
+    )
+
+    payload = request_obj.model_dump(mode="json")
+    response = client.post("/api/v1/admin/streams/setup", json=payload)
+
+    # 에러 발생 시 상세 내용을 확인하기 위해 로깅 추가
+    if response.status_code != 201:
+        print(f"Validation Error Detail: {response.json()}")
+
+    assert response.status_code == 201
+    data = response.json()
+    assert data["id"] == 999
+    assert data["title"] == "테스트 콘서트"
+
+
+def test_user_credentials_endpoint(client: TestClient) -> None:
+    """유저 시청 권한 발급 API 테스트"""
+    concert_id = 999
+    response = client.get(f"/api/v1/streams/{concert_id}/credentials")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert "playback_url" in data
+    assert data["access_token"] == "mock_access"
+
+
+@pytest.mark.asyncio
+async def test_permission_denied_for_normal_user(mock_service):
+    """일반 유저가 관리자 기능을 호출할 때의 권한 체크(Service Level)"""
+    from fastapi import HTTPException
+
+    # Given: 일반 유저 준비
+    normal_user = MagicMock(spec=User)
+    normal_user.is_superuser = False
+
+    # 실제 서비스 인스턴스 (Mock 아님) 사용하여 로직 검증
+    # StreamPermission.must_be_admin(user) 가 내부에서 작동하는지 확인
+    from app.domains.streams.service import StreamService
+
+    service = StreamService(MagicMock(), MagicMock())
+
+    # When & Then
+    with pytest.raises(HTTPException) as exc:
+        await service.create_concert_and_channel(MagicMock(), normal_user)
+
+    assert exc.value.status_code == 403

--- a/tests/streams/test_service.py
+++ b/tests/streams/test_service.py
@@ -62,6 +62,7 @@ async def test_create_concert_and_channel_admin_success(monkeypatch):
         "title": "test",
         "access_level": AccessLevel.PUBLIC,
     }
+    data.artist_ids = []
     data.channel_config = MagicMock()
     data.channel_config.latency_mode.value = "LOW"
     data.channel_config.channel_type.value = "STANDARD"

--- a/tests/streams/test_service.py
+++ b/tests/streams/test_service.py
@@ -1,0 +1,157 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.domains.streams.models import AccessLevel, Concert, StreamChannel
+from app.domains.streams.schemas import ConcertCreateRequest
+from app.domains.streams.service import StreamService
+from app.domains.users.models import User
+
+
+@pytest.mark.asyncio
+async def test_create_concert_and_channel_admin_success(monkeypatch):
+    """관리자는 공연, 스트림 채널 생성 가능"""
+    admin = MagicMock(spec=User)
+    admin.is_superuser = True
+
+    # 권한 체크는 통과만 시킴
+    monkeypatch.setattr(
+        "app.domains.streams.permissions.StreamPermission.must_be_admin",
+        MagicMock(),
+    )
+
+    # Concert 생성 mock
+    concert = MagicMock(spec=Concert)
+    concert.id = 1
+    concert.access_level = AccessLevel.PUBLIC
+
+    monkeypatch.setattr(
+        "app.domains.streams.service.Concert.create",
+        AsyncMock(return_value=concert),
+    )
+
+    # StreamChannel 생성 mock
+    channel = MagicMock(spec=StreamChannel)
+    monkeypatch.setattr(
+        "app.domains.streams.service.StreamChannel.create",
+        AsyncMock(return_value=channel),
+    )
+
+    # IVS 채널 생성 응답 mock
+    ivs_client = MagicMock()
+    ivs_client.create_channel.return_value = {
+        "channel": {
+            "arn": "arn:test",
+            "ingestEndpoint": "ingest",
+            "playbackUrl": "playback",
+        },
+        "streamKey": {"value": "secret"},
+    }
+
+    # 스트림 키 저장 및 DB 저장 mock
+    channel.set_stream_key = MagicMock()
+    channel.save = AsyncMock()
+
+    playback_provider = MagicMock()
+
+    service = StreamService(ivs_client, playback_provider)
+
+    # 요청 데이터 mock
+    data = MagicMock(spec=ConcertCreateRequest)
+    data.model_dump.return_value = {
+        "title": "test",
+        "access_level": AccessLevel.PUBLIC,
+    }
+    data.channel_config = MagicMock()
+    data.channel_config.latency_mode.value = "LOW"
+    data.channel_config.channel_type.value = "STANDARD"
+
+    result = await service.create_concert_and_channel(data=data, user=admin)
+
+    # 생성된 Concert 반환
+    assert result is concert
+
+    # IVS 채널 생성 호출 여부 확인
+    ivs_client.create_channel.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_public_channel_does_not_add_playback_token(monkeypatch):
+    """PUBLIC은 playback token 없어도 URL 줌"""
+    user = MagicMock(spec=User)
+    user.id = 1
+    user.is_superuser = False
+
+    channel = MagicMock(spec=StreamChannel)
+    channel.is_private = False
+    channel.playback_url = "https://example.m3u8"
+    channel.channel_arn = "arn:test"
+
+    concert = MagicMock(spec=Concert)
+    concert.id = 10
+    concert.stream_channel = channel
+    concert.access_level = AccessLevel.PUBLIC
+
+    # Concert 조회 + stream_channel preload mock
+    fake_qs = MagicMock()
+    fake_qs.prefetch_related = AsyncMock(return_value=concert)
+
+    monkeypatch.setattr(
+        "app.domains.streams.service.Concert.get",
+        MagicMock(return_value=fake_qs),
+    )
+
+    playback_provider = MagicMock()
+    playback_provider.sign_internal_tokens.return_value = {
+        "access_token": "access",
+        "refresh_token": "refresh",
+    }
+
+    service = StreamService(MagicMock(), playback_provider)
+
+    result = await service.get_viewing_credentials(concert_id=10, user=user)
+
+    # playback URL 확인
+    assert result["playback_url"] == "https://example.m3u8"
+    playback_provider.sign_playback_token.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_private_channel_adds_playback_token(monkeypatch):
+    """SPECIFIC은 playback token이 URL 뒤에 붙음"""
+    user = MagicMock(spec=User)
+    user.id = 1
+    user.is_superuser = False
+
+    channel = MagicMock(spec=StreamChannel)
+    channel.is_private = True
+    channel.playback_url = "https://example.m3u8"
+    channel.channel_arn = "arn:test"
+
+    concert = MagicMock(spec=Concert)
+    concert.id = 10
+    concert.stream_channel = channel
+    concert.access_level = AccessLevel.PUBLIC
+
+    fake_qs = MagicMock()
+    fake_qs.prefetch_related = AsyncMock(return_value=concert)
+
+    monkeypatch.setattr(
+        "app.domains.streams.service.Concert.get",
+        MagicMock(return_value=fake_qs),
+    )
+
+    playback_provider = MagicMock()
+    playback_provider.sign_playback_token.return_value = "signed-token"
+    playback_provider.sign_internal_tokens.return_value = {
+        "access_token": "access",
+        "refresh_token": "refresh",
+    }
+
+    service = StreamService(MagicMock(), playback_provider)
+
+    result = await service.get_viewing_credentials(concert_id=10, user=user)
+
+    # # playback token이 URL 뒤에 붙었나 확인
+    assert "?token=signed-token" in result["playback_url"]
+    playback_provider.sign_playback_token.assert_called_once()


### PR DESCRIPTION
## ✅ PR 한줄 요약
- 방송 세팅


## 🔗 관련 이슈
- Jira: NEAR-48

## 🛠️ 변경 내용
- [x] pyproject.toml에 Depends 사용을 위해 ignore = ["B008"] 추가 (ruff 설정 변경)
- [x] 스트림 권한 설정
- [x] 콘서트 생성, 토큰발급 api 구현

## 🧪 테스트
- [x] 로컬 테스트 완료


## ✅ 체크리스트
- [x] ruff 설정 변경했습니다. pyproject.toml에 Depends 사용을 위해 ignore = ["B008"] 추가