### PR TITLE
NEAR-46 내 프로필 상세 정보 조회 기능 및 테스트 구현

### DIFF
--- a/app/domains/users/router.py
+++ b/app/domains/users/router.py
@@ -1,18 +1,33 @@
-"""users 도메인 HTTP 라우터.
+from typing import Annotated, Any
 
-여기에 넣을 것:
-- APIRouter(prefix='...', tags=[...])
-- endpoints 정의(GET/POST/PATCH/DELETE)
-- Depends로 인증/권한 체크
-- service 함수를 호출해서 결과 반환
+from fastapi import APIRouter, Depends, status
 
-예:
-- GET /users
-- POST /users
-"""
-
-from fastapi import APIRouter
+from app.api.deps import get_current_user
+from app.domains.users.models import User
+from app.domains.users.schemas import UserMeResponse
+from app.domains.users.service import user_service
 
 router = APIRouter(prefix="/users", tags=["users"])
 
-# TODO: endpoints 추가
+
+@router.get(
+    "/me",
+    response_model=UserMeResponse,
+    status_code=status.HTTP_200_OK,
+    summary="내 프로필 조회",
+    description="""
+    현재 로그인한 사용자의 상세 정보를 조회합니다.
+    - **기본 정보**: 이메일, 닉네임, 실명, 프로필 이미지 등
+    - **활동 정보**: 팔로우 중인 아티스트 리스트
+    - **설정 정보**: 선호 카테고리 및 개인화된 알림 설정 상태
+    """,
+    responses={
+        401: {"description": "인증되지 않은 사용자 (토큰 만료 또는 누락)"},
+        404: {"description": "사용자 정보를 찾을 수 없음"},
+    },
+)
+async def get_my_profile(
+    current_user: Annotated[User, Depends(get_current_user)],
+) -> dict[str, Any]:
+    """내 프로필 정보를 반환합니다."""
+    return await user_service.get_user_profile(current_user.id)

--- a/app/domains/users/schemas.py
+++ b/app/domains/users/schemas.py
@@ -16,6 +16,9 @@ class NotiSettings(BaseModel):
 
 
 class UserMeResponse(BaseModel):
+    # class Config: ... 대체
+    model_config = ConfigDict(from_attributes=True)
+
     id: int
     email: str | None
     nickname: str
@@ -28,7 +31,3 @@ class UserMeResponse(BaseModel):
     favorite_artists: list[ArtistSimple]
     preferred_categories: list[str]
     notification_settings: NotiSettings
-
-    class Config:
-        from_attributes = True  # Tortoise 객체를 자동으로 Pydantic으로 변환
-        model_config = ConfigDict(from_attributes=True)

--- a/app/domains/users/service.py
+++ b/app/domains/users/service.py
@@ -1,10 +1,50 @@
-"""users 도메인 서비스(비즈니스 로직).
+from typing import TYPE_CHECKING, Any, cast
 
-여기에 넣을 것:
-- router에서 호출할 함수들
-  - create_*, update_*, delete_*, list_*, get_*
-- DB 접근(Tortoise 쿼리) + 검증/권한체크 + 외부연동 호출(integrations)
+from app.domains.users.models import User, UserCatFav
 
-규칙:
-- router.py에는 로직을 최소화하고, 실제 처리는 service로 내려보내기.
-"""
+if TYPE_CHECKING:
+    # 런타임에는 필요 없지만 타입 힌트용으로만 쓰이는 임포트
+    from collections.abc import Iterable
+
+
+class UserService:
+    async def get_user_profile(self, user_id: int) -> dict[str, Any]:
+        """
+        사용자의 상세 프로필 정보를 조회합니다.
+        (팔로우한 아티스트, 알림 설정, 선호 카테고리 포함)
+        """
+
+        # 이미 인증이 완료된 current_user 객체를 바로 사용
+        user = await User.get(id=user_id).prefetch_related(
+            "followed_artists", "noti_setting", "fav_categories"
+        )
+
+        notis = user.noti_setting
+        fav_categories = cast("Iterable[UserCatFav]", user.fav_categories)
+
+        return {
+            "id": user.id,
+            "email": user.email,
+            "nickname": user.nickname,
+            "name": user.real_name,
+            "profile_image": user.profile_img_url,
+            "joined_at": user.created_at,
+            "bio": user.bio,
+            "favorite_artists": [
+                {
+                    "id": artist.id,
+                    "name": artist.stage_name,
+                    "profile_image": artist.profile_img_url,
+                }
+                for artist in user.followed_artists
+            ],
+            "preferred_categories": [cat.category.value for cat in fav_categories],
+            "notification_settings": {
+                "new_content_from_favorite_artists": notis.artist_noti if notis else True,
+                "live_start_notification": notis.live_noti if notis else True,
+                "marketing_consent": notis.marketing_noti if notis else False,
+            },
+        }
+
+
+user_service = UserService()

--- a/tests/test_user_service.py
+++ b/tests/test_user_service.py
@@ -1,0 +1,82 @@
+from datetime import date
+
+import pytest
+
+from app.domains.artists.models import Artist
+from app.domains.notifications.models import UserNoti
+from app.domains.streams.models import CategoryType
+from app.domains.users.models import GenderChoices, ProviderChoice, User, UserCatFav
+from app.domains.users.service import user_service
+
+
+@pytest.mark.asyncio
+async def test_get_user_profile_success(initialize_tests):
+    # 1. 테스트 유저 생성
+    user = await User.create(
+        provider=ProviderChoice.KAKAO,
+        provider_id="kakao_12345",
+        email="test@example.com",
+        nickname="test_nick",
+        real_name="김테스트",
+        profile_img_url="http://example.com/profile.jpg",
+        bio="안녕하세요!",
+        gender=GenderChoices.M,
+        birth_date=date(1995, 1, 1),
+    )
+
+    # 2. 알림 설정 생성 (UserNoti 모델의 필드명은 위 서비스 코드 로직에 맞춤)
+    # 서비스에서 artist_noti, live_noti, marketing_noti를 참조하므로 해당 필드명 사용
+    await UserNoti.create(user=user, artist_noti=False, live_noti=True, marketing_noti=True)
+
+    # 3. 팔로우 아티스트 생성 및 관계 추가
+    artist = await Artist.create(
+        stage_name="뉴진스", profile_img_url="http://example.com/artist.jpg"
+    )
+    await user.followed_artists.add(artist)
+
+    # 4. 선호 카테고리 추가 (CategoryType Enum 사용)
+    # CategoryType에 KPOP, DANCE 등의 값이 있다고 가정합니다.
+    await UserCatFav.create(user=user, category=CategoryType.KPOP)
+    await UserCatFav.create(user=user, category=CategoryType.BAND)
+
+    # 5. 서비스 메서드 호출
+    profile = await user_service.get_user_profile(user.id)
+
+    # 6. 검증
+    assert profile["id"] == user.id
+    assert profile["nickname"] == "test_nick"
+    assert profile["email"] == "test@example.com"
+    assert profile["name"] == "김테스트"
+
+    # 아티스트 데이터 검증
+    assert len(profile["favorite_artists"]) == 1
+    assert profile["favorite_artists"][0]["name"] == "뉴진스"
+
+    # 카테고리 Enum 값 검증 (.value)
+    assert CategoryType.KPOP.value in profile["preferred_categories"]
+    assert CategoryType.BAND.value in profile["preferred_categories"]
+
+    # 알림 설정 검증
+    notis = profile["notification_settings"]
+    assert notis["new_content_from_favorite_artists"] is False
+    assert notis["live_start_notification"] is True
+    assert notis["marketing_consent"] is True
+
+
+@pytest.mark.asyncio
+async def test_get_user_profile_no_relation_data(initialize_tests):
+    """관계 데이터(알림, 아티스트, 카테고리)가 전혀 없는 경우의 기본 동작 검증"""
+    user = await User.create(
+        provider=ProviderChoice.GOOGLE, provider_id="google_999", nickname="pure_user"
+    )
+
+    profile = await user_service.get_user_profile(user.id)
+
+    assert profile["favorite_artists"] == []
+    assert profile["preferred_categories"] == []
+
+    # 서비스 로직 내의 default 처리 검증
+    notis = profile["notification_settings"]
+    assert notis["new_content_from_favorite_artists"] is True
+    assert notis["live_start_notification"] is True
+    assert notis["marketing_consent"] is False


### PR DESCRIPTION
✅ PR 한줄 요약
로그인한 사용자의 개인화된 상세 프로필 정보를 조회하는 API 및 비즈니스 로직을 구현하고 테스트를 완료했습니다.

🔗 관련 이슈
Jira: NEAR-46
GitHub: #46

🛠️ 변경 내용
[x] 사용자 정보 조회 API 구현: GET /api/v1/users/me 엔드포인트를 통해 사용자 통합 정보 반환
[x] UserService 고도화: 기본 정보, 팔로우 아티스트, 알림 설정, 선호 카테고리를 통합 조회하는 get_user_profile 메서드 구현
[x] 응답 스키마 정의: UserMeResponse, NotiSettings 등 클라이언트 대응을 위한 Pydantic 모델 추가
[x] 비즈니스 로직 테스트 추가: 다양한 사용자 상태(데이터 유무 등)에 따른 서비스 레이어 유닛 테스트 구현

🧪 테스트
[x] 로컬 테스트 완료
[x] ruff/mypy 통과 확인
[x] uv run ruff check .
[x] uv run ruff format --check .
[x] uv run mypy .

⚠️ 리뷰 포인트 / 주의사항
데이터 조회 최적화: 사용자와 연결된 여러 테이블(Artists, Notifications, Categories)을 조회할 때 N+1 문제를 방지하기 위해 prefetch_related를 사용했습니다. 효율적으로 쿼리가 나가는지 확인 부탁드립니다.
Pydantic V2 반영: 기존 class Config 대신 model_config = ConfigDict(from_attributes=True) 형식을 적용하여 향후 버전 호환성을 높였습니다.

✅ 체크리스트
[x] 커밋 메시지 컨벤션을 준수했습니다.
[x] 불필요한 주석/로그를 제거했습니다.
[x] UserMeResponse 스키마에 필요한 필드가 모두 포함되었는지 확인했습니다.