### PR TITLE
Near 48 setup concert channel

### DIFF
--- a/app/api/router.py
+++ b/app/api/router.py
@@ -17,6 +17,7 @@ from app.domains.auth.router import router as auth_router
 from app.domains.chat.router_ws import router as chat_router
 from app.domains.notifications.router import router as notifications_router
 from app.domains.streams.router import router as streams_router
+from app.domains.streams.router_admin import router as streams_admin_router
 from app.domains.users.router import router as users_router
 
 api_router = APIRouter(prefix="/api/v1")
@@ -26,5 +27,6 @@ api_router.include_router(auth_router)
 api_router.include_router(users_router)
 api_router.include_router(artists_router)
 api_router.include_router(streams_router)
+api_router.include_router(streams_admin_router)
 api_router.include_router(chat_router)
 api_router.include_router(notifications_router)

--- a/app/domains/streams/deps.py
+++ b/app/domains/streams/deps.py
@@ -1,0 +1,23 @@
+from app.domains.streams.service import StreamAdminService, StreamUserService
+from app.integrations.aws_ivs import IVSClient, IVSPlaybackProvider
+
+
+def get_ivs_client() -> IVSClient:
+    return IVSClient()
+
+
+def get_playback_provider() -> IVSPlaybackProvider:
+    return IVSPlaybackProvider()
+
+
+# 1. Admin 전용 서비스 주입
+def get_stream_admin_service() -> StreamAdminService:
+    return StreamAdminService(ivs_client=get_ivs_client())
+
+
+# 2. User 전용 서비스 주입
+def get_stream_user_service() -> StreamUserService:
+    return StreamUserService(
+        ivs_client=get_ivs_client(),  # 채널 조회용
+        playback_provider=get_playback_provider(),  # 토큰 발행용
+    )

--- a/app/domains/streams/permissions.py
+++ b/app/domains/streams/permissions.py
@@ -1,10 +1,33 @@
-"""streams 권한 체크 모듈.
+from fastapi import HTTPException
 
-여기에 넣을 것:
-- 스트리밍 시청 가능 여부(유료/무료, 구매, 권한 등)
-- 어드민만 가능한 작업(생성/수정/삭제) 체크
-- 채팅 참여 가능 여부(시청권한 기반)
+from app.domains.streams.models import AccessLevel, ConcertSession
+from app.domains.users.models import User
 
-구조:
-- router/service에서 if문으로 흩어놓지 말고 여기 함수로 모으기.
-"""
+
+class StreamPermission:
+    @staticmethod
+    def must_be_admin(user: User) -> None:
+        if not user.is_superuser:
+            raise HTTPException(403, "관리자만 접근이 가능합니다.")
+
+    @staticmethod
+    async def verify_playback_access(user: User, session: ConcertSession) -> None:
+        """
+        유저가 IVS 토큰을 발급받을 자격이 있는지 확인
+        """
+        if user.is_superuser or session.access_level == AccessLevel.PUBLIC:
+            return
+
+        if session.access_level == AccessLevel.ADMIN_ONLY:
+            raise HTTPException(403, "테스트 중인 방송입니다.")
+
+        # from app.domains.orders.models import UserTicket
+        if session.access_level == AccessLevel.SPECIFIC:
+            # TODO: 유료/무료 공연 기능 추가 -> 티켓 구매 여부 확인
+            # has_ticket = await UserTicket.filter(
+            #     user=user, concert=concert, is_valid=True
+            # ).exists()
+            # 지금은 없으니까 그냥 False로 에러 띄움
+            has_ticket = False
+            if not has_ticket:
+                raise HTTPException(402, "티켓 구매가 필요한 공연입니다.")

--- a/app/domains/streams/router.py
+++ b/app/domains/streams/router.py
@@ -1,18 +1,52 @@
-"""streams 도메인 HTTP 라우터.
+from typing import Any
 
-여기에 넣을 것:
-- APIRouter(prefix='...', tags=[...])
-- endpoints 정의(GET/POST/PATCH/DELETE)
-- Depends로 인증/권한 체크
-- service 함수를 호출해서 결과 반환
+from fastapi import APIRouter, Body, Depends, Path
 
-예:
-- GET /streams
-- POST /streams
-"""
+from app.api import deps
+from app.domains.streams import deps as streams_deps
+from app.domains.streams.service import StreamUserService
+from app.domains.users.models import User
 
-from fastapi import APIRouter
+router = APIRouter(prefix="/streams", tags=["Streaming"])
 
-router = APIRouter(prefix="/streams", tags=["streams"])
 
-# TODO: endpoints 추가
+@router.get(
+    "/sessions/{session_id}/credentials",
+    summary="스트림 시청 권한 확인 - 토큰 발급",
+    description="실시간 스트리밍 시청을 위한 Playback URL과 인증 토큰을 발급합니다. \
+                \n\n 비공개 채널의 경우 IVS Playback Token이 포함됩니다.",
+)
+async def get_stream_access(
+    session_id: int = Path(..., description="콘서트 세션 ID"),
+    current_user: User = Depends(deps.get_current_user),
+    service: StreamUserService = Depends(streams_deps.get_stream_user_service),
+) -> dict[str, Any]:
+    """
+    1. 유저의 세션 시청 자격(티켓 등)을 검증합니다.
+    2. AWS IVS 채널 설정에 따라 Playback Token 서명 여부를 결정합니다.
+    3. 채팅 서버 인증을 위한 내부 세션 토큰을 함께 반환합니다.
+    """
+    return await service.get_viewing_credentials(session_id, current_user)
+
+
+@router.post(
+    "/sessions/{session_id}/refresh",
+    summary="시청 세션 연장 (토큰 재발급)",
+    description="시청 중 토큰이 만료되기 전, 기존 리프레시 토큰을 사용해 세션을 연장합니다. \
+                 \n\n 이때 유저의 시청 자격을 재검증합니다.",
+)
+async def refresh_stream_session(
+    session_id: int = Path(..., description="콘서트 세션 ID"),
+    refresh_token: str = Body(..., embed=True),  # json body에서 refresh_token 추출
+    current_user: User = Depends(deps.get_current_user),
+    service: StreamUserService = Depends(streams_deps.get_stream_user_service),
+) -> dict[str, Any]:
+    """
+    1. 유저의 리프레시 토큰을 검증하고 새로운 Access/Refresh 토큰 세트를 생성합니다.
+    2. 동시에 새로운 유효기간을 가진 AWS IVS 재생 토큰을 발급받아 반환합니다.
+    """
+    return await service.refresh_viewing_session(
+        session_id,
+        current_user,
+        refresh_token,
+    )

--- a/app/domains/streams/router_admin.py
+++ b/app/domains/streams/router_admin.py
@@ -1,0 +1,52 @@
+from fastapi import APIRouter, Body, Depends, Path, status
+
+from app.api import deps
+from app.domains.streams import deps as streams_deps
+from app.domains.streams.models import Concert
+from app.domains.streams.schemas import (
+    ConcertCreateRequest,
+    ConcertResponse,
+    SessionCreateRequest,
+    SessionResponse,
+)
+from app.domains.streams.service import StreamAdminService
+from app.domains.users.models import User
+
+router = APIRouter(prefix="/admin/streams", tags=["[Admin] Streaming"])
+
+
+@router.post(
+    "/concerts",
+    status_code=status.HTTP_201_CREATED,
+    response_model=ConcertResponse,
+    summary="콘서트 메타정보 생성",
+    description="신규 콘서트의 기본 메타데이터(제목, 카테고리 등)를 생성합니다. \
+    인프라 리소스는 생성되지 않습니다.",
+)
+async def create_concert(
+    data: ConcertCreateRequest,
+    current_user: User = Depends(deps.get_current_user),
+    service: StreamAdminService = Depends(streams_deps.get_stream_admin_service),
+) -> Concert:
+    return await service.create_concert(data, current_user)
+
+
+@router.post(
+    "/concerts/{concert_id}/sessions",
+    status_code=status.HTTP_201_CREATED,
+    summary="콘서트 세션 생성 - IVS 채널 자동 설정",
+    response_model=SessionResponse,
+    description="특정 콘서트의 회차를 생성하고, AWS IVS 채널 리소스를 자동으로 할당합니다.",
+)
+async def create_concert_stream(
+    concert_id: int = Path(..., description="콘서트 ID"),
+    data: SessionCreateRequest = Body(..., description="새로운 콘서트 세션과 IVS config 상세 정보"),
+    current_user: User = Depends(deps.get_current_user),
+    service: StreamAdminService = Depends(streams_deps.get_stream_admin_service),
+) -> SessionResponse:
+    """
+    1. 콘서트 회차(Session) 레코드를 생성합니다.
+    2. AWS IVS `CreateChannel` API를 호출하여 송출/재생 엔드포인트를 확보합니다.
+    3. 발급된 스트림 키는 내부 보안 정책에 따라 암호화하여 저장합니다.
+    """
+    return await service.create_session_with_infrastructure(concert_id, data, current_user)

--- a/app/domains/streams/schemas.py
+++ b/app/domains/streams/schemas.py
@@ -1,9 +1,77 @@
-"""streams 도메인 Pydantic 스키마.
+from datetime import datetime
 
-여기에 넣을 것:
-- Request/Response 모델들
-- 예: CreateRequest, UpdateRequest, ListResponse, DetailResponse
+from pydantic import BaseModel, ConfigDict, Field
 
-팁:
-- 외부로 노출되는 응답 스키마는 항상 schemas에 모으는게 추적하기 쉬움.
-"""
+from app.domains.streams.models import AccessLevel, CategoryType, ChannelType, LatencyMode
+
+
+class ChannelConfig(BaseModel):
+    """IVS 채널 생성 상세 설정"""
+
+    latency_mode: LatencyMode = Field(default=LatencyMode.LOW)
+    channel_type: ChannelType = Field(default=ChannelType.STANDARD)
+
+
+# ==================== 요청 스키마 ====================
+class ConcertCreateRequest(BaseModel):
+    """콘서트 생성 요청 스키마"""
+
+    category: CategoryType
+    title: str = Field(..., min_length=1, max_length=100)
+    description: str | None = None
+    thumbnail_url: str | None = None
+
+
+class SessionCreateRequest(BaseModel):
+    """콘서트 세션 생성 요청 스키마"""
+
+    session_name: str = Field(..., min_length=1, max_length=100)
+    start_at: datetime
+    end_at: datetime | None = None
+    access_level: AccessLevel = Field(default=AccessLevel.PUBLIC)
+    is_test: bool = Field(default=False)
+
+    # 검색/필터링을 위한 아티스트 연결
+    artist_ids: list[int] = Field(default_factory=list, description="출연 아티스트 ID 목록")
+
+    # 채널 설정 (기본값 제공)
+    channel_config: ChannelConfig = Field(default_factory=ChannelConfig)
+
+
+# ==================== 응답 스키마 ====================
+
+
+class IVSChannelSummary(BaseModel):
+    """AWS IVS 채널 정보 요약"""
+
+    channel_arn: str
+    ingest_endpoint: str
+    playback_url: str
+    latency_mode: LatencyMode
+    channel_type: ChannelType
+
+
+class ConcertResponse(BaseModel):
+    """콘서트 생성 최종 응답"""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    title: str
+    category: CategoryType
+    created_at: datetime
+
+
+class SessionResponse(BaseModel):
+    """세션 생성 최종 응답"""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int = Field(..., description="내부 세션 ID")
+    session_name: str
+    access_level: AccessLevel
+    start_at: datetime
+
+    # 인프라 정보는 별도 객체로 분리
+    channel: IVSChannelSummary | None = None
+    stream_key: str | None = Field(None, description="생성 시에만 일회성으로 노출되는 스트림 키")

--- a/app/domains/streams/schemas.py
+++ b/app/domains/streams/schemas.py
@@ -59,6 +59,7 @@ class ConcertResponse(BaseModel):
     id: int
     title: str
     category: CategoryType
+    description: str | None = None
     created_at: datetime
 
 

--- a/app/domains/streams/service.py
+++ b/app/domains/streams/service.py
@@ -1,10 +1,158 @@
-"""streams 도메인 서비스(비즈니스 로직).
+from typing import Any
 
-여기에 넣을 것:
-- router에서 호출할 함수들
-  - create_*, update_*, delete_*, list_*, get_*
-- DB 접근(Tortoise 쿼리) + 검증/권한체크 + 외부연동 호출(integrations)
+from app.domains.streams.models import (
+    AccessLevel,
+    Concert,
+    ConcertArtist,
+    ConcertSession,
+    StreamChannel,
+)
+from app.domains.streams.permissions import StreamPermission
+from app.domains.streams.schemas import ConcertCreateRequest, SessionCreateRequest, SessionResponse
+from app.domains.users.models import User
+from app.integrations.aws_ivs import IVSClient, IVSPlaybackProvider
 
-규칙:
-- router.py에는 로직을 최소화하고, 실제 처리는 service로 내려보내기.
-"""
+
+class StreamAdminService:
+    def __init__(self, ivs_client: IVSClient):
+        self.ivs_client = ivs_client
+
+    async def create_concert(self, data: ConcertCreateRequest, user: User) -> Concert:
+        """
+        [Admin] 콘서트 생성
+        """
+        StreamPermission.must_be_admin(user)
+        return await Concert.create(**data.model_dump())
+
+    async def create_session_with_infrastructure(
+        self, concert_id: int, data: SessionCreateRequest, user: User
+    ) -> SessionResponse:
+        """
+        [Admin] 콘서트 세션 생성 및 AWS IVS 채널 자동 발급
+        """
+        # 권한 체크
+        StreamPermission.must_be_admin(user)
+
+        # Concert 있나 확인
+        concert = await Concert.get(id=concert_id)
+
+        # 콘서트 세션 (실제 회차) 생성
+        # channel_config는 IVS 설정용이므로 DB 모델 생성시에는 제외
+        session_dict = data.model_dump(exclude={"channel_config", "artist_ids"})
+        session = await ConcertSession.create(concert=concert, **session_dict)
+
+        # 출연 아티스트 매핑
+        if data.artist_ids:
+            for artist_id in data.artist_ids:
+                await ConcertArtist.create(session=session, artist_id=artist_id)
+
+        # IVS 채널 생성 호출
+        config = data.channel_config
+        stream_key_raw = ""  # 평문 키 보관용
+
+        ivs_res = self.ivs_client.create_channel(
+            name=f"session-{session.id}",
+            latency_mode=config.latency_mode.value,
+            channel_type=config.channel_type.value,
+            authorized=(session.access_level != AccessLevel.PUBLIC),
+        )
+        stream_key_raw = ivs_res["streamKey"]["value"]
+
+        # StreamChannel(IVS 정보) DB 저장 및 스트림 키 암호화
+        channel = await StreamChannel.create(
+            session=session,
+            type=config.channel_type,
+            latency_mode=config.latency_mode,
+            channel_arn=ivs_res["channel"]["arn"],
+            ingest_endpoint=ivs_res["channel"]["ingestEndpoint"],
+            playback_url=ivs_res["channel"]["playbackUrl"],
+            is_private=(session.access_level != AccessLevel.PUBLIC),
+        )
+
+        channel.set_stream_key(stream_key_raw)
+        await channel.save()
+
+        from app.domains.streams.schemas import IVSChannelSummary
+
+        return SessionResponse(
+            id=session.id,
+            session_name=session.session_name,
+            access_level=session.access_level,
+            start_at=session.start_at,
+            channel=IVSChannelSummary(
+                channel_arn=channel.channel_arn,
+                ingest_endpoint=channel.ingest_endpoint,
+                playback_url=channel.playback_url,
+                latency_mode=channel.latency_mode,
+                channel_type=channel.type,
+            ),
+            stream_key=stream_key_raw,  # 생성 시점에만 평문 노출
+        )
+
+
+class StreamUserService:
+    def __init__(self, ivs_client: IVSClient, playback_provider: IVSPlaybackProvider):
+        self.ivs_client = ivs_client
+        self.playback_provider = playback_provider
+
+    async def get_viewing_credentials(self, session_id: int, user: User) -> dict[str, Any]:
+        """
+        [User] 시청 권한 확인 및 최초 재생/채팅 토큰 발급
+        """
+        session = await ConcertSession.get(id=session_id).prefetch_related("stream_channel")
+
+        # 유저 권한 증명
+        await StreamPermission.verify_playback_access(user, session)
+
+        channel: StreamChannel = session.stream_channel
+        playback_url: str = channel.playback_url
+
+        # 비공개 채널이면 토큰 서명
+        if channel.is_private:
+            token = self.playback_provider.sign_playback_token(
+                channel_arn=channel.channel_arn, viewer_id=str(user.id)
+            )
+            playback_url = f"{playback_url}?token={token}"
+
+        # 내부 세션 토큰
+        internal_tokens = self.playback_provider.sign_internal_tokens(
+            user_id=str(user.id), stream_id=str(channel.id)
+        )
+
+        return {
+            "playback_url": playback_url,
+            "stream_id": channel.id,
+            "access_token": internal_tokens["access_token"],
+            "refresh_token": internal_tokens["refresh_token"],
+        }
+
+    async def refresh_viewing_session(
+        self, session_id: int, user: User, refresh_token: str
+    ) -> dict[str, Any]:
+        """
+        [User] 시청 중인 세션 연장 (아마존 권장: 연장 시마다 권한 재검증)
+        """
+        # 대상 세션, 채널 조회
+        session = await ConcertSession.get(id=session_id).prefetch_related("stream_channel")
+
+        # 갱신 시점에 다시 권한 체크
+        await StreamPermission.verify_playback_access(user, session)
+
+        # 기존 리프레시 토큰으로 새 토큰 Access/Refresh 발급
+        new_tokens = self.playback_provider.rotate_tokens(refresh_token)
+
+        # IVS 재생 토큰 새 유효기간으로 재서명
+        channel: StreamChannel = session.stream_channel
+        playback_url: str = channel.playback_url
+
+        if channel.is_private:
+            token = self.playback_provider.sign_playback_token(
+                channel_arn=channel.channel_arn, viewer_id=str(user.id)
+            )
+            playback_url = f"{playback_url}?token={token}"
+
+        return {
+            "playback_url": playback_url,
+            "access_token": new_tokens["access_token"],
+            "refresh_token": new_tokens["refresh_token"],
+        }

--- a/app/integrations/aws_ivs/__init__.py
+++ b/app/integrations/aws_ivs/__init__.py
@@ -4,3 +4,11 @@ app/integrations/aws_ivs/
 - client.py: boto3/SDK 래핑 (채널 생성/삭제, 스트림키 등)
 - playback.py: playback token 발급/검증 정책(시청권한/만료/리프레시 등)
 """
+
+from app.integrations.aws_ivs.client import IVSClient
+from app.integrations.aws_ivs.playback import IVSPlaybackProvider
+
+__all__ = [
+    "IVSClient",
+    "IVSPlaybackProvider",
+]

--- a/app/integrations/aws_ivs/playback.py
+++ b/app/integrations/aws_ivs/playback.py
@@ -46,6 +46,7 @@ class IVSPlaybackProvider:
         """
         [IVS 전용] 비공개 채널 시청 토큰 발급 (ES384 서명)
         - Playback URL 뒤에 '?token=' 파라미터로 붙음
+        - 재생 세션보다 짧은 TTL
         """
         if not self._ivs_private_key:
             raise RuntimeError("IVS_PLAYBACK_PRIVATE_KEY가 설정되지 않았습니다.")
@@ -71,27 +72,27 @@ class IVSPlaybackProvider:
         access_exp = now + (30 * 60)  # 30분
         refresh_exp = now + (7 * 24 * 3600)  # 7일
 
-        access_payload: InternalTokenPayload = {
-            "sub": user_id,
-            "stream_id": stream_id,
-            "type": "access",
-            "iat": now,
-            "exp": access_exp,
-        }
-        refresh_payload: InternalTokenPayload = {
-            "sub": user_id,
-            "type": "refresh",
-            "stream_id": stream_id,
-            "iat": now,
-            "exp": refresh_exp,
-        }
+        def _encode(payload: dict[str, Any]) -> str:
+            return jwt.encode(payload, self._secret, algorithm=self._algo_internal)
 
         return {
-            "access_token": jwt.encode(
-                cast("dict[str, Any]", access_payload), self._secret, algorithm=self._algo_internal
+            "access_token": _encode(
+                {
+                    "sub": user_id,
+                    "stream_id": stream_id,
+                    "type": "access",
+                    "iat": now,
+                    "exp": access_exp,
+                }
             ),
-            "refresh_token": jwt.encode(
-                cast("dict[str, Any]", refresh_payload), self._secret, algorithm=self._algo_internal
+            "refresh_token": _encode(
+                {
+                    "sub": user_id,
+                    "stream_id": stream_id,
+                    "type": "refresh",
+                    "iat": now,
+                    "exp": refresh_exp,
+                }
             ),
         }
 
@@ -119,31 +120,12 @@ class IVSPlaybackProvider:
 
     # ===================== playback_token 재발급 =====================
 
-    def refresh_access_token(self, refresh_token: str) -> str:
-        """
-        [내부 세션] 유효한 Refresh Token을 기반으로 새로운 Access Token 생성
-        """
-        # Refresh Token 검증
-        payload = self.verify_internal_token(refresh_token, expected_type="refresh")
-
-        # 새로운 Access Token 발급
-        now = int(time.time())
-        new_access_payload: InternalTokenPayload = {
-            "sub": payload["sub"],
-            "stream_id": payload["stream_id"],
-            "type": "access",
-            "iat": now,
-            "exp": now + (30 * 60),
-        }
-        return jwt.encode(
-            cast("dict[str, Any]", new_access_payload), self._secret, algorithm=self._algo_internal
-        )
-
     def rotate_tokens(self, refresh_token: str) -> dict[str, str]:
         """
         [내부 세션] Access와 Refresh 토큰을 모두 새로 발급 (Refresh Token Rotation)
         """
         payload = self.verify_internal_token(refresh_token, expected_type="refresh")
+        # 기존 페이로드 정보를 바탕으로 새 토큰(Access + Refresh) 발급
         return self.sign_internal_tokens(user_id=payload["sub"], stream_id=payload["stream_id"])
 
     # ===================================================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ exclude = [
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "B", "UP", "C4", "SIM", "TCH"]
+ignore = ["B008"] # FastAPI의 Depends 사용을 위해 추가
 
 [tool.mypy]
 plugins = ["pydantic.mypy"]

--- a/tests/integrations/aws_ivs/test_playback.py
+++ b/tests/integrations/aws_ivs/test_playback.py
@@ -7,117 +7,52 @@ from app.integrations.aws_ivs.playback import IVSPlaybackProvider
 
 
 @pytest.fixture
-def provider() -> IVSPlaybackProvider:
+def provider():
     return IVSPlaybackProvider()
 
 
 class TestIVSPlaybackProvider:
-    # --- IVS 재생 토큰 (ES384) 테스트 ---
-
-    def test_sign_playback_token_success(self, provider: IVSPlaybackProvider):
-        # Given
-        channel_arn = "arn:aws:ivs:ap-northeast-2:123456789012:channel/test-channel"
-        viewer_id = "user_123"
-
-        # When
-        token = provider.sign_playback_token(channel_arn, viewer_id)
-
-        # Then
-        assert isinstance(token, str)
-        # 디코딩 검증 (알고리즘 확인)
+    def test_sign_playback_token(self, provider):
+        # IVS Playback Token 생성 및 규격 확인
+        token = provider.sign_playback_token("arn:aws:ivs:test", "viewer1")
         decoded = jwt.decode(token, provider._ivs_private_key, algorithms=["ES384"])
-        assert decoded["aws:channel-arn"] == channel_arn
-        assert decoded["aws:viewer-id"] == viewer_id
-        assert decoded["exp"] > decoded["iat"]
+        assert decoded["aws:channel-arn"] == "arn:aws:ivs:test"
+        assert decoded["aws:viewer-id"] == "viewer1"
 
-    # --- 내부 세션 토큰 (HS256) 테스트 ---
+    def test_internal_token_full_cycle(self, provider):
+        # 토큰 발급
+        tokens = provider.sign_internal_tokens("user1", "stream1")
 
-    def test_sign_internal_tokens(self, provider: IVSPlaybackProvider):
-        # Given
-        user_id = "user_123"
-        stream_id = "stream_456"
-
-        # When
-        tokens = provider.sign_internal_tokens(user_id, stream_id)
-
-        # Then
-        assert "access_token" in tokens
-        assert "refresh_token" in tokens
-
-        # Access 토큰 내용 검증
-        decoded = jwt.decode(tokens["access_token"], provider._secret, algorithms=["HS256"])
-        assert decoded["sub"] == user_id
-        assert decoded["stream_id"] == stream_id
-        assert decoded["type"] == "access"
-
-    def test_verify_internal_token_success(self, provider: IVSPlaybackProvider):
-        # Given
-        tokens = provider.sign_internal_tokens("u1", "s1")
-
-        # When & Then (정상 케이스)
+        # 검증 (정상)
         payload = provider.verify_internal_token(tokens["access_token"], expected_type="access")
-        assert payload["sub"] == "u1"
+        assert payload["sub"] == "user1"
 
-    def test_verify_internal_token_invalid_type(self, provider: IVSPlaybackProvider):
-        # Given (Access 토큰을 넘기면서 Refresh 타입을 기대함)
-        tokens = provider.sign_internal_tokens("u1", "s1")
-
-        # When & Then
+        # 토큰 타입 불일치 에러
         with pytest.raises(ValueError, match="토큰 타입 불일치"):
             provider.verify_internal_token(tokens["access_token"], expected_type="refresh")
 
-    def test_verify_internal_token_expired(self, provider: IVSPlaybackProvider):
-        # Given - 이미 만료된 토큰을 직접 생성
-        past_time = int(time.time()) - (8 * 24 * 3600)  # 8일 전
+        # 만료된 토큰 처리
         expired_payload = {
-            "sub": "u1",
-            "stream_id": "s1",
-            "type": "refresh",
-            "iat": past_time,
-            "exp": past_time + (7 * 24 * 3600),  # 1일 전에 만료됨
+            "sub": "u",
+            "stream_id": "s",
+            "type": "access",
+            "iat": int(time.time()) - 4000,
+            "exp": int(time.time()) - 1000,
         }
         expired_token = jwt.encode(expired_payload, provider._secret, algorithm="HS256")
-
-        # When & Then
         with pytest.raises(ValueError, match="토큰이 만료되었습니다"):
-            provider.verify_internal_token(expired_token, expected_type="refresh")
+            provider.verify_internal_token(expired_token, "access")
 
-    # --- 재발급 및 유틸리티 테스트 ---
+        # 유효하지 않은 토큰
+        with pytest.raises(ValueError, match="유효하지 않은 토큰입니다"):
+            provider.verify_internal_token("invalid.token.here", "access")
 
-    def test_refresh_access_token(self, provider: IVSPlaybackProvider):
-        # Given
-        tokens = provider.sign_internal_tokens("u1", "s1")
+        # 토큰 재발급
+        time.sleep(1.1)  # iat 변경 보장
+        new_tokens = provider.rotate_tokens(tokens["refresh_token"])
+        assert tokens["access_token"] != new_tokens["access_token"]
 
-        # When
-        new_access_token = provider.refresh_access_token(tokens["refresh_token"])
-
-        # Then
-        payload = provider.verify_internal_token(new_access_token, expected_type="access")
-        assert payload["sub"] == "u1"
-        assert payload["stream_id"] == "s1"
-
-    def test_rotate_tokens(self, provider: IVSPlaybackProvider):
-        # Given
-        old_tokens = provider.sign_internal_tokens("u1", "s1")
-
-        # When
-        new_tokens = provider.rotate_tokens(old_tokens["refresh_token"])
-
-        # Then
-        assert "access_token" in new_tokens
-        assert "refresh_token" in new_tokens
-
-        # 새 토큰이 유효한지 확인
-        decoded = jwt.decode(new_tokens["refresh_token"], provider._secret, algorithms=["HS256"])
-        assert decoded["sub"] == "u1"
-        assert decoded["stream_id"] == "s1"
-
-    def test_get_internal_token_remaining_time(self, provider: IVSPlaybackProvider):
-        # Given
-        tokens = provider.sign_internal_tokens("u1", "s1")
-
-        # When
-        remaining = provider.get_internal_token_remaining_time(tokens["access_token"])
-
-        # Then (기본 30분 설정이므로 약 1800초 내외)
-        assert 1700 < remaining <= 1800
+        # 남은 시간 조회
+        rem = provider.get_internal_token_remaining_time(tokens["access_token"])
+        assert 1700 < rem <= 1800
+        assert provider.get_internal_token_remaining_time("wrong") == 0

--- a/tests/streams/test_deps.py
+++ b/tests/streams/test_deps.py
@@ -1,0 +1,30 @@
+from app.domains.streams import deps
+
+
+def test_get_ivs_client():
+    """IVS Client 생성 테스트"""
+    client = deps.get_ivs_client()
+    assert client is not None
+    assert hasattr(client, "create_channel")
+
+
+def test_get_playback_provider():
+    """Playback Provider 생성 테스트"""
+    provider = deps.get_playback_provider()
+    assert provider is not None
+    assert hasattr(provider, "sign_playback_token")
+
+
+def test_get_stream_admin_service():
+    """Admin Service DI 테스트"""
+    service = deps.get_stream_admin_service()
+    assert service is not None
+    assert service.ivs_client is not None
+
+
+def test_get_stream_user_service():
+    """User Service DI 테스트"""
+    service = deps.get_stream_user_service()
+    assert service is not None
+    assert service.ivs_client is not None
+    assert service.playback_provider is not None

--- a/tests/streams/test_permissions.py
+++ b/tests/streams/test_permissions.py
@@ -1,0 +1,44 @@
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from app.domains.streams.models import AccessLevel
+from app.domains.streams.permissions import StreamPermission
+
+
+@pytest.mark.asyncio
+class TestStreamPermission:
+    def test_must_be_admin(self):
+        # 관리자 통과
+        admin = MagicMock(is_superuser=True)
+        StreamPermission.must_be_admin(admin)
+
+        # 일반인 거부
+        user = MagicMock(is_superuser=False)
+        with pytest.raises(HTTPException) as exc:
+            StreamPermission.must_be_admin(user)
+        assert exc.value.status_code == 403
+
+    async def test_verify_playback_access_logic(self):
+        # 슈퍼유저 프리패스
+        admin = MagicMock(is_superuser=True)
+        await StreamPermission.verify_playback_access(admin, MagicMock())
+
+        user = MagicMock(is_superuser=False)
+
+        # PUBLIC 허용
+        pub_session = MagicMock(access_level=AccessLevel.PUBLIC)
+        await StreamPermission.verify_playback_access(user, pub_session)
+
+        # ADMIN_ONLY 거부
+        adm_session = MagicMock(access_level=AccessLevel.ADMIN_ONLY)
+        with pytest.raises(HTTPException) as exc:
+            await StreamPermission.verify_playback_access(user, adm_session)
+        assert exc.value.status_code == 403
+
+        # SPECIFIC 티켓 없음 거부
+        spec_session = MagicMock(access_level=AccessLevel.SPECIFIC)
+        with pytest.raises(HTTPException) as exc:
+            await StreamPermission.verify_playback_access(user, spec_session)
+        assert exc.value.status_code == 402

--- a/tests/streams/test_router.py
+++ b/tests/streams/test_router.py
@@ -1,0 +1,226 @@
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.api.deps import get_current_user
+from app.domains.streams.models import AccessLevel, ChannelType, LatencyMode
+from app.main import app
+
+
+class TestStreamRouter:
+    @pytest.fixture
+    async def client(self):
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as ac:
+            yield ac
+
+    @pytest.fixture
+    def mock_admin_user(self):
+        """관리자 권한"""
+        user = MagicMock()
+        user.id = 1
+        user.is_admin = True
+        return user
+
+    @pytest.fixture
+    def mock_regular_user(self):
+        """일반 사용자 권한"""
+        user = MagicMock()
+        user.id = 2
+        user.is_admin = False
+        return user
+
+    # ========================= 어드민 테스트 =========================
+
+    @pytest.mark.asyncio
+    async def test_admin_router_success_flow(self, client, mock_admin_user):
+        """관리자 권한으로 콘서트 생성 → 세션 생성 성공하는지 검증"""
+
+        async def override_get_current_user():
+            return mock_admin_user
+
+        app.dependency_overrides[get_current_user] = override_get_current_user
+
+        try:
+            with (
+                patch(
+                    "app.domains.streams.service.StreamAdminService.create_concert",
+                    new_callable=AsyncMock,
+                ) as mock_create_concert,
+                patch(
+                    "app.domains.streams.service.StreamAdminService.create_session_with_infrastructure",
+                    new_callable=AsyncMock,
+                ) as mock_create_session,
+            ):
+                # concert mock
+                mock_concert = MagicMock()
+                mock_concert.id = 1
+                mock_concert.title = "Test Concert"
+                mock_concert.description = "Test Description"
+                mock_concert.category = "K-POP"
+                mock_concert.created_at = datetime.now()
+                mock_create_concert.return_value = mock_concert
+
+                # create concert
+                res = await client.post(
+                    "/api/v1/admin/streams/concerts",
+                    json={
+                        "title": "Test Concert",
+                        "description": "Test Description",
+                        "category": "K-POP",
+                    },
+                )
+
+                assert res.status_code == 201
+                assert res.json()["title"] == "Test Concert"
+
+                # session mock
+                from app.domains.streams.schemas import (
+                    IVSChannelSummary,
+                    SessionResponse,
+                )
+
+                mock_create_session.return_value = SessionResponse(
+                    id=10,
+                    session_name="Session 1",
+                    access_level=AccessLevel.PUBLIC,
+                    start_at=datetime.now(),
+                    channel=IVSChannelSummary(
+                        channel_arn="arn:test",
+                        ingest_endpoint="rtmps://test",
+                        playback_url="https://test.m3u8",
+                        latency_mode=LatencyMode.LOW,
+                        channel_type=ChannelType.STANDARD,
+                    ),
+                    stream_key="sk_test",
+                )
+
+                # create session
+                res = await client.post(
+                    "/api/v1/admin/streams/concerts/1/sessions",
+                    json={
+                        "session_name": "Session 1",
+                        "access_level": "PUBLIC",
+                        "start_at": datetime.now().isoformat(),
+                        "channel_config": {
+                            "latency_mode": "LOW",
+                            "channel_type": "STANDARD",
+                        },
+                        "artist_ids": [1, 2],
+                    },
+                )
+
+                assert res.status_code == 201
+                assert res.json()["stream_key"] == "sk_test"
+
+        finally:
+            app.dependency_overrides.clear()
+
+    # ========================= 유저 테스트 =========================
+    @pytest.mark.asyncio
+    async def test_user_router_get_credentials(self, client, mock_regular_user):
+        """일반 사용자가 스트림 세션에 대한 시청 자격 및 토큰을 정상적으로 발급받는지 검증"""
+
+        async def override_get_current_user():
+            return mock_regular_user
+
+        app.dependency_overrides[get_current_user] = override_get_current_user
+
+        try:
+            with patch(
+                "app.domains.streams.service.StreamUserService.get_viewing_credentials",
+                new_callable=AsyncMock,
+            ) as mock_get_credentials:
+                mock_get_credentials.return_value = {
+                    "playback_url": "https://test.m3u8",
+                    "stream_id": 100,
+                    "access_token": "access",
+                    "refresh_token": "refresh",
+                }
+
+                res = await client.get("/api/v1/streams/sessions/10/credentials")
+
+                assert res.status_code == 200
+                assert res.json()["stream_id"] == 100
+
+        finally:
+            app.dependency_overrides.clear()
+
+    # -------------------------
+    # user: refresh
+    # -------------------------
+    @pytest.mark.asyncio
+    async def test_user_router_refresh_session(self, client, mock_regular_user):
+        """일반 사용자가 기존 refresh token으로 시청 세션 연장, 새 토큰 발급받는지 검증"""
+
+        async def override_get_current_user():
+            return mock_regular_user
+
+        app.dependency_overrides[get_current_user] = override_get_current_user
+
+        try:
+            with patch(
+                "app.domains.streams.service.StreamUserService.refresh_viewing_session",
+                new_callable=AsyncMock,
+            ) as mock_refresh:
+                mock_refresh.return_value = {
+                    "access_token": "new_access",
+                    "refresh_token": "new_refresh",
+                    "playback_url": "https://test.m3u8",
+                }
+
+                res = await client.post(
+                    "/api/v1/streams/sessions/10/refresh",
+                    json={"refresh_token": "old"},
+                )
+
+                assert res.status_code == 200
+
+                mock_refresh.assert_called_once_with(
+                    10,
+                    mock_regular_user,
+                    "old",
+                )
+
+        finally:
+            app.dependency_overrides.clear()
+
+    # -------------------------
+    # validation: 422
+    # -------------------------
+    @pytest.mark.asyncio
+    async def test_validation_error_handling(self, client, mock_admin_user):
+        async def override_get_current_user():
+            return mock_admin_user
+
+        app.dependency_overrides[get_current_user] = override_get_current_user
+
+        try:
+            # missing title
+            res = await client.post(
+                "/api/v1/admin/streams/concerts",
+                json={"description": "missing title"},
+            )
+            assert res.status_code == 422
+
+            # invalid enum
+            res = await client.post(
+                "/api/v1/admin/streams/concerts/1/sessions",
+                json={
+                    "session_name": "Session",
+                    "access_level": "INVALID",
+                    "start_at": datetime.now().isoformat(),
+                    "channel_config": {
+                        "latency_mode": "LOW",
+                        "channel_type": "STANDARD",
+                    },
+                },
+            )
+            assert res.status_code == 422
+
+        finally:
+            app.dependency_overrides.clear()

--- a/tests/streams/test_service.py
+++ b/tests/streams/test_service.py
@@ -1,0 +1,309 @@
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.domains.streams.models import AccessLevel, ChannelType, LatencyMode
+from app.domains.streams.schemas import (
+    ChannelConfig,
+    ConcertCreateRequest,
+    SessionCreateRequest,
+)
+from app.domains.streams.service import StreamAdminService, StreamUserService
+
+
+class TestStreamService:
+    @pytest.mark.asyncio
+    async def test_admin_service_coverage(self):
+        """Admin 서비스 커버리지 테스트 - 콘서트 및 세션 생성"""
+
+        # Mock IVS Client
+        mock_ivs_client = MagicMock()
+        mock_ivs_client.create_channel = MagicMock(
+            return_value={
+                "channel": {
+                    "arn": "arn:aws:ivs:region:account:channel/test-channel",
+                    "ingestEndpoint": "rtmps://test.global-contribute.live-video.net:443/app/",
+                    "playbackUrl": "https://test.us-west-2.playback.live-video.net/api/video/v1/test.m3u8",
+                },
+                "streamKey": {
+                    "value": "sk_test_stream_key_12345",
+                },
+            }
+        )
+
+        service = StreamAdminService(ivs_client=mock_ivs_client)
+
+        # Mock User (admin)
+        mock_user = MagicMock()
+        mock_user.is_admin = True
+        mock_user.id = 1
+
+        # 콘서트 생성 테스트
+        concert_data = ConcertCreateRequest(
+            title="Test Concert",
+            description="Test Description",
+            category="K-POP",
+        )
+
+        with patch(
+            "app.domains.streams.models.Concert.create", new_callable=AsyncMock
+        ) as mock_create_concert:
+            mock_concert = MagicMock()
+            mock_concert.id = 1
+            mock_concert.title = "Test Concert"
+            mock_create_concert.return_value = mock_concert
+
+            concert = await service.create_concert(concert_data, mock_user)
+
+            assert concert.id == 1
+            assert concert.title == "Test Concert"
+            mock_create_concert.assert_called_once()
+
+        # 세션 생성 테스트
+        session_data = SessionCreateRequest(
+            session_name="Session 1",
+            access_level=AccessLevel.PUBLIC,
+            start_at=datetime.now(),
+            channel_config=ChannelConfig(
+                latency_mode=LatencyMode.LOW,
+                channel_type=ChannelType.STANDARD,
+            ),
+            artist_ids=[1, 2],
+        )
+
+        with (
+            patch(
+                "app.domains.streams.models.Concert.get", new_callable=AsyncMock
+            ) as mock_get_concert,
+            patch(
+                "app.domains.streams.models.ConcertSession.create", new_callable=AsyncMock
+            ) as mock_create_session,
+            patch(
+                "app.domains.streams.models.ConcertArtist.create", new_callable=AsyncMock
+            ) as mock_create_artist,
+            patch(
+                "app.domains.streams.models.StreamChannel.create", new_callable=AsyncMock
+            ) as mock_create_channel,
+        ):
+            # Mock Concert
+            mock_concert = MagicMock()
+            mock_concert.id = 1
+            mock_get_concert.return_value = mock_concert
+
+            # Mock Session
+            mock_session = MagicMock()
+            mock_session.id = 10
+            mock_session.session_name = "Session 1"
+            mock_session.access_level = AccessLevel.PUBLIC
+            mock_session.start_at = session_data.start_at
+            mock_create_session.return_value = mock_session
+
+            # Mock Channel
+            mock_channel = MagicMock()
+            mock_channel.id = 100
+            mock_channel.channel_arn = "arn:aws:ivs:region:account:channel/test-channel"
+            mock_channel.ingest_endpoint = "rtmps://test.global-contribute.live-video.net:443/app/"
+            mock_channel.playback_url = (
+                "https://test.us-west-2.playback.live-video.net/api/video/v1/test.m3u8"
+            )
+            mock_channel.latency_mode = LatencyMode.LOW
+            mock_channel.type = ChannelType.STANDARD
+            mock_channel.is_private = False
+            mock_channel.set_stream_key = MagicMock()
+            mock_channel.save = AsyncMock()
+            mock_create_channel.return_value = mock_channel
+
+            response = await service.create_session_with_infrastructure(
+                concert_id=1,
+                data=session_data,
+                user=mock_user,
+            )
+
+            # 검증
+            assert response.id == 10
+            assert response.session_name == "Session 1"
+            assert response.stream_key == "sk_test_stream_key_12345"
+
+            # IVS 채널 생성 호출 확인
+            mock_ivs_client.create_channel.assert_called_once()
+
+            # 아티스트 매핑 확인
+            assert mock_create_artist.call_count == 2
+
+            # 채널 저장 확인
+            mock_channel.save.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_user_service_viewing_coverage(self):
+        """User 서비스 커버리지 테스트 - 시청 권한 및 토큰 발급"""
+
+        # Mock IVS Client & Playback Provider
+        mock_ivs_client = MagicMock()
+        mock_playback_provider = MagicMock()
+        mock_playback_provider.sign_playback_token = MagicMock(
+            return_value="signed_playback_token_abc123"
+        )
+        mock_playback_provider.sign_internal_tokens = MagicMock(
+            return_value={
+                "access_token": "access_token_xyz",
+                "refresh_token": "refresh_token_xyz",
+            }
+        )
+        mock_playback_provider.rotate_tokens = MagicMock(
+            return_value={
+                "access_token": "new_access_token",
+                "refresh_token": "new_refresh_token",
+            }
+        )
+
+        service = StreamUserService(
+            ivs_client=mock_ivs_client,
+            playback_provider=mock_playback_provider,
+        )
+
+        # Mock User
+        mock_user = MagicMock()
+        mock_user.id = 1
+        mock_user.is_admin = False
+
+        # Mock Session & Channel
+        mock_channel = MagicMock()
+        mock_channel.id = 100
+        mock_channel.channel_arn = "arn:aws:ivs:region:account:channel/test"
+        mock_channel.playback_url = "https://test.playback.live-video.net/api/video/v1/test.m3u8"
+        mock_channel.is_private = True
+
+        mock_session = MagicMock()
+        mock_session.id = 10
+        mock_session.stream_channel = mock_channel
+        # AccessLevel enum 값 확인 필요 - PUBLIC 외 다른 값 사용
+        # TICKETED가 없다면 PUBLIC이 아닌 다른 값으로 테스트
+        mock_session.access_level = AccessLevel.PUBLIC  # 일단 PUBLIC으로 테스트
+
+        # 1. 시청 권한 확인 및 토큰 발급 테스트
+        with (
+            patch("app.domains.streams.models.ConcertSession.get") as mock_get_session,
+            patch(
+                "app.domains.streams.permissions.StreamPermission.verify_playback_access",
+                new_callable=AsyncMock,
+            ),
+        ):
+            # AsyncMock으로 await 가능하게 설정
+            async def mock_prefetch(*args, **kwargs):
+                return mock_session
+
+            mock_get_result = MagicMock()
+            mock_get_result.prefetch_related = mock_prefetch
+            mock_get_session.return_value = mock_get_result
+
+            credentials = await service.get_viewing_credentials(
+                session_id=10,
+                user=mock_user,
+            )
+
+            # 검증
+            assert "playback_url" in credentials
+            assert "token=signed_playback_token_abc123" in credentials["playback_url"]
+            assert credentials["stream_id"] == 100
+            assert credentials["access_token"] == "access_token_xyz"
+            assert credentials["refresh_token"] == "refresh_token_xyz"
+
+            # 토큰 서명 호출 확인
+            mock_playback_provider.sign_playback_token.assert_called_once_with(
+                channel_arn=mock_channel.channel_arn,
+                viewer_id="1",
+            )
+            mock_playback_provider.sign_internal_tokens.assert_called_once()
+
+        # 시청 세션 연장 테스트
+        with (
+            patch("app.domains.streams.models.ConcertSession.get") as mock_get_session,
+            patch(
+                "app.domains.streams.permissions.StreamPermission.verify_playback_access",
+                new_callable=AsyncMock,
+            ),
+        ):
+
+            async def mock_prefetch(*args, **kwargs):
+                return mock_session
+
+            mock_get_result = MagicMock()
+            mock_get_result.prefetch_related = mock_prefetch
+            mock_get_session.return_value = mock_get_result
+
+            refreshed = await service.refresh_viewing_session(
+                session_id=10,
+                user=mock_user,
+                refresh_token="old_refresh_token",
+            )
+
+            # 검증
+            assert "playback_url" in refreshed
+            assert refreshed["access_token"] == "new_access_token"
+            assert refreshed["refresh_token"] == "new_refresh_token"
+
+            # 토큰 갱신 호출 확인
+            mock_playback_provider.rotate_tokens.assert_called_once_with("old_refresh_token")
+
+    @pytest.mark.asyncio
+    async def test_user_service_public_channel(self):
+        """공개 채널의 경우 Playback Token 없이 URL만 반환"""
+
+        mock_ivs_client = MagicMock()
+        mock_playback_provider = MagicMock()
+        mock_playback_provider.sign_internal_tokens = MagicMock(
+            return_value={
+                "access_token": "access_token_public",
+                "refresh_token": "refresh_token_public",
+            }
+        )
+        mock_playback_provider.sign_playback_token = MagicMock()
+
+        service = StreamUserService(
+            ivs_client=mock_ivs_client,
+            playback_provider=mock_playback_provider,
+        )
+
+        mock_user = MagicMock()
+        mock_user.id = 2
+
+        mock_channel = MagicMock()
+        mock_channel.id = 200
+        mock_channel.channel_arn = "arn:aws:ivs:region:account:channel/public"
+        mock_channel.playback_url = (
+            "https://public.playback.live-video.net/api/video/v1/public.m3u8"
+        )
+        mock_channel.is_private = False  # 공개 채널
+
+        mock_session = MagicMock()
+        mock_session.id = 20
+        mock_session.stream_channel = mock_channel
+        mock_session.access_level = AccessLevel.PUBLIC
+
+        with (
+            patch("app.domains.streams.models.ConcertSession.get") as mock_get_session,
+            patch(
+                "app.domains.streams.permissions.StreamPermission.verify_playback_access",
+                new_callable=AsyncMock,
+            ),
+        ):
+
+            async def mock_prefetch(*args, **kwargs):
+                return mock_session
+
+            mock_get_result = MagicMock()
+            mock_get_result.prefetch_related = mock_prefetch
+            mock_get_session.return_value = mock_get_result
+
+            credentials = await service.get_viewing_credentials(
+                session_id=20,
+                user=mock_user,
+            )
+
+            # 공개 채널은 토큰 파라미터가 없어야 함
+            assert "token=" not in credentials["playback_url"]
+            assert credentials["playback_url"] == mock_channel.playback_url
+
+            # Playback 토큰 서명은 호출되지 않아야 함
+            mock_playback_provider.sign_playback_token.assert_not_called()


### PR DESCRIPTION
## ✅ PR 한줄 요약
- 콘서트 중간 테이블 생성하고 콘서트 퓨어 crud로 함 + 콘서트 세션 만들면 채널 자동 생성. 토큰 검증

## 🔗 관련 이슈
- Jira: NEAR-48

## 🛠️ 변경 내용
- [x] 콘서트 생성
- [x] 채널 생성
- [x] 토큰 발급 + 검증(유저)
- [x] 토큰 재발급

## 🧪 테스트
- [x] 로컬 테스트 완료 (`uv run pytest -q`)
- [x] ruff/mypy 통과 확인
  - [x] `uv run ruff check .`
  - [x] `uv run ruff format --check .`
  - [x] `uv run mypy .`

## ⚠️ 리뷰 포인트 / 주의사항
- pyproject.toml 수정함 → ruff 관련
- 테스트코드가 많아요. 빼고 보면 얼마 안 바뀜.. 아마도요?

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했습니다.
- [x] 불필요한 주석/로그를 제거했습니다.
- [x] 문서/설정 변경이 필요하면 반영했습니다.