### PR TITLE
Near 83 rotate session stream key

### DIFF
--- a/app/domains/streams/admin/router.py
+++ b/app/domains/streams/admin/router.py
@@ -56,6 +56,49 @@ async def create_concert_stream(
     return await service.create_session_with_infrastructure(concert_id, data, current_user)
 
 
+@router.delete(
+    "/sessions/{session_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="콘서트 세션 및 인프라 삭제",
+    description="특정 세션을 삭제하고, 연결된 AWS IVS 채널 리소스를 즉시 삭제",
+)
+async def delete_concert_session(
+    session_id: int = Path(..., description="삭제할 세션 ID"),
+    current_user: User = Depends(deps.get_current_user),
+    service: StreamAdminService = Depends(streams_deps.get_stream_admin_service),
+) -> None:
+    return await service.delete_session_with_infrastructure(session_id, current_user)
+
+
+@router.post(
+    "/sessions/{session_id}/rotate-key",
+    summary="스트림 키 강제 재발급 (보안)",
+    description="기존의 모든 스트림 키를 무효화(삭제)하고 새로운 키 생성 \
+                 스트림 키가 유출되었을 때 사용합니다.",
+)
+async def rotate_session_stream_key(
+    session_id: int = Path(..., description="키를 갱신할 세션 ID"),
+    current_user: User = Depends(deps.get_current_user),
+    service: StreamAdminService = Depends(streams_deps.get_stream_admin_service),
+) -> dict[str, str]:
+    new_key = await service.rotate_stream_key(session_id, current_user)
+    return {"message": "스트림 키가 재발급되었습니다.", "value": new_key}
+
+
+@router.post(
+    "/sessions/{session_id}/stop",
+    summary="라이브 방송 강제 종료",
+    description="현재 진행 중인 AWS IVS 스트림 송출을 강제 중단시키고, 세션 상태를 'ENDED'로 변경",
+)
+async def stop_live_stream(
+    session_id: int = Path(..., description="중단할 세션 ID"),
+    current_user: User = Depends(deps.get_current_user),
+    service: StreamAdminService = Depends(streams_deps.get_stream_admin_service),
+) -> dict[str, str]:
+    await service.stop_stream_session(session_id, current_user)
+    return {"message": "방송이 종료 처리되었습니다."}
+
+
 @router.get(
     "/sessions/{session_id}/ingest",
     response_model=StreamIngestResponse,

--- a/app/domains/streams/admin/router.py
+++ b/app/domains/streams/admin/router.py
@@ -2,7 +2,6 @@ from fastapi import APIRouter, Body, Depends, Path, Request, status
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 
-from app.api import deps
 from app.domains.streams import deps as streams_deps
 from app.domains.streams.admin.schemas import (
     ConcertCreateRequest,
@@ -12,6 +11,7 @@ from app.domains.streams.admin.schemas import (
     StreamIngestResponse,
 )
 from app.domains.streams.admin.service import StreamAdminService
+from app.domains.streams.deps import get_admin_user
 from app.domains.streams.models import Concert
 from app.domains.users.models import User
 
@@ -29,10 +29,10 @@ templates = Jinja2Templates(directory="templates")
 )
 async def create_concert(
     data: ConcertCreateRequest,
-    current_user: User = Depends(deps.get_current_user),
+    current_admin: User = Depends(get_admin_user),
     service: StreamAdminService = Depends(streams_deps.get_stream_admin_service),
 ) -> Concert:
-    return await service.create_concert(data, current_user)
+    return await service.create_concert(data, current_admin)
 
 
 @router.post(
@@ -45,7 +45,7 @@ async def create_concert(
 async def create_concert_stream(
     concert_id: int = Path(..., description="콘서트 ID"),
     data: SessionCreateRequest = Body(..., description="새로운 콘서트 세션과 IVS config 상세 정보"),
-    current_user: User = Depends(deps.get_current_user),
+    current_admin: User = Depends(get_admin_user),
     service: StreamAdminService = Depends(streams_deps.get_stream_admin_service),
 ) -> SessionResponse:
     """
@@ -53,7 +53,7 @@ async def create_concert_stream(
     2. AWS IVS `CreateChannel` API를 호출하여 송출/재생 엔드포인트를 확보합니다.
     3. 발급된 스트림 키는 내부 보안 정책에 따라 암호화하여 저장합니다.
     """
-    return await service.create_session_with_infrastructure(concert_id, data, current_user)
+    return await service.create_session_with_infrastructure(concert_id, data, current_admin)
 
 
 @router.delete(
@@ -64,10 +64,10 @@ async def create_concert_stream(
 )
 async def delete_concert_session(
     session_id: int = Path(..., description="삭제할 세션 ID"),
-    current_user: User = Depends(deps.get_current_user),
+    current_admin: User = Depends(get_admin_user),
     service: StreamAdminService = Depends(streams_deps.get_stream_admin_service),
 ) -> None:
-    return await service.delete_session_with_infrastructure(session_id, current_user)
+    return await service.delete_session_with_infrastructure(session_id, current_admin)
 
 
 @router.post(
@@ -78,10 +78,10 @@ async def delete_concert_session(
 )
 async def rotate_session_stream_key(
     session_id: int = Path(..., description="키를 갱신할 세션 ID"),
-    current_user: User = Depends(deps.get_current_user),
+    current_admin: User = Depends(get_admin_user),
     service: StreamAdminService = Depends(streams_deps.get_stream_admin_service),
 ) -> dict[str, str]:
-    new_key = await service.rotate_stream_key(session_id, current_user)
+    new_key = await service.rotate_stream_key(session_id, current_admin)
     return {"message": "스트림 키가 재발급되었습니다.", "value": new_key}
 
 
@@ -92,10 +92,10 @@ async def rotate_session_stream_key(
 )
 async def stop_live_stream(
     session_id: int = Path(..., description="중단할 세션 ID"),
-    current_user: User = Depends(deps.get_current_user),
+    current_admin: User = Depends(get_admin_user),
     service: StreamAdminService = Depends(streams_deps.get_stream_admin_service),
 ) -> dict[str, str]:
-    await service.stop_stream_session(session_id, current_user)
+    await service.stop_stream_session(session_id, current_admin)
     return {"message": "방송이 종료 처리되었습니다."}
 
 
@@ -108,10 +108,10 @@ async def stop_live_stream(
 )
 async def get_session_ingest_data(
     session_id: int = Path(..., description="콘서트 세션 ID"),
-    current_user: User = Depends(deps.get_current_user),
+    current_admin: User = Depends(get_admin_user),
     service: StreamAdminService = Depends(streams_deps.get_stream_admin_service),
 ) -> StreamIngestResponse:
-    return await service.get_stream_ingest_info(session_id, current_user)
+    return await service.get_stream_ingest_info(session_id, user=current_admin)
 
 
 @router.get(
@@ -124,8 +124,9 @@ async def get_session_ingest_data(
 async def stream_monitor_page(
     request: Request,
     session_id: int = Path(..., description="모니터링할 콘서트 세션 ID"),
+    current_admin: User = Depends(get_admin_user),
 ) -> HTMLResponse:
     return templates.TemplateResponse(
         "stream_monitor.html",
-        {"request": request, "session_id": session_id},
+        {"request": request, "session_id": session_id, "is_admin": current_admin.is_superuser},
     )

--- a/app/domains/streams/admin/schemas.py
+++ b/app/domains/streams/admin/schemas.py
@@ -117,4 +117,5 @@ class StreamIngestResponse(BaseModel):
     concert_title: str
     ingest_info: StreamIngestInfo
     playback_url: str
+    playback_token: str | None = None
     live_metrics: StreamLiveMetrics | None = None

--- a/app/domains/streams/admin/service.py
+++ b/app/domains/streams/admin/service.py
@@ -21,6 +21,7 @@ from app.domains.streams.models import (
 from app.domains.streams.permissions import StreamPermission
 from app.domains.users.models import User
 from app.integrations.aws_ivs import IVSClient
+from app.integrations.aws_ivs.client import logger
 
 
 class StreamAdminService:
@@ -101,6 +102,11 @@ class StreamAdminService:
                     status_code=500, detail=f"DB 저장 실패로 인프라를 롤백했습니다: {str(db_error)}"
                 ) from db_error
 
+        except HTTPException:
+            if "session" in locals() and session.id:
+                await session.delete()
+            raise
+
         except Exception as e:
             # IVS 세팅 실패했으면 콘서트 세션 삭제
             if "session" in locals() and session.id:
@@ -131,6 +137,75 @@ class StreamAdminService:
             ),
             value=stream_key_raw,  # 생성 시점에만 평문 노출
         )
+
+    async def rotate_stream_key(self, session_id: int, user: User) -> str:
+        """
+        [Admin] 스트림 키 유출 시 재발급
+        """
+        StreamPermission.must_be_admin(user)
+
+        session = await ConcertSession.get(id=session_id).prefetch_related("stream_channel")
+        channel = session.stream_channel
+
+        # 스트림 키 삭제
+        existing_keys = self.ivs_client.list_all_stream_keys(channel.channel_arn)
+        for k in existing_keys:
+            self.ivs_client.delete_stream_key(k["arn"])
+
+        # 새 스트림 키 생성
+        new_key_res = self.ivs_client.create_stream_key(channel.channel_arn)
+        new_key_raw = new_key_res["streamKey"]["value"]
+
+        # DB 업데이트 (암호화 저장)
+        channel.set_stream_key(new_key_raw)
+        await channel.save(update_fields=["stream_key_encrypted"])
+
+        return new_key_raw
+
+    async def delete_session_with_infrastructure(self, session_id: int, user: User) -> None:
+        """
+        [Admin] 세션 삭제 및 연결된 IVS 채널 영구 제거
+        """
+        StreamPermission.must_be_admin(user)
+
+        # 채널 정보 조회를 위해 관계 로드
+        session = await ConcertSession.get_or_none(id=session_id).prefetch_related("stream_channel")
+        if not session:
+            raise HTTPException(404, "존재하지 않는 세션입니다.")
+
+        # IVS 채널 삭제
+        if hasattr(session, "stream_channel") and session.stream_channel:
+            try:
+                self.ivs_client.delete_channel(session.stream_channel.channel_arn)
+            except Exception as e:
+                # 이미 AWS에서 지워졌을 수도 있으니까
+                logger.warning(f"AWS 채널 삭제 실패(이미 제거되었을 수 있음): {str(e)}")
+
+            # DB 삭제
+            await session.delete()
+
+    async def stop_stream_session(self, session_id: int, user: User) -> None:
+        """
+        [Admin] 라이브 방송 강제 중단 및 상태 종료 처리
+        """
+        StreamPermission.must_be_admin(user)
+
+        session = await ConcertSession.get(id=session_id).prefetch_related("stream_channel")
+        channel = session.stream_channel
+
+        if not channel:
+            raise HTTPException(404, "연결된 스트리밍 채널이 없습니다.")
+
+        # IVS 송출 강제 중단
+        try:
+            self.ivs_client.stop_stream(channel.channel_arn)
+        except Exception as e:
+            # 방송 중이 아닐 때 stop 호출하면 안되니까
+            logger.warning(f"AWS StopStream 호출 실패(이미 종료되었을 수 있음): {str(e)}")
+
+        # DB 상태 업데이트
+        session.status = StreamStatus.ENDED
+        await session.save(update_fields=["status"])
 
     async def get_stream_ingest_info(self, session_id: int, user: User) -> StreamIngestResponse:
         """

--- a/app/domains/streams/admin/service.py
+++ b/app/domains/streams/admin/service.py
@@ -20,13 +20,14 @@ from app.domains.streams.models import (
 )
 from app.domains.streams.permissions import StreamPermission
 from app.domains.users.models import User
-from app.integrations.aws_ivs import IVSClient
+from app.integrations.aws_ivs import IVSClient, IVSPlaybackProvider
 from app.integrations.aws_ivs.client import logger
 
 
 class StreamAdminService:
-    def __init__(self, ivs_client: IVSClient):
+    def __init__(self, ivs_client: IVSClient, playback_provider: IVSPlaybackProvider):
         self.ivs_client = ivs_client
+        self.playback_provider = playback_provider
 
     async def create_concert(self, data: ConcertCreateRequest, user: User) -> Concert:
         """
@@ -221,7 +222,17 @@ class StreamAdminService:
         channel = session.stream_channel
 
         if not channel:
-            raise HTTPException(404, "해당 세션에 연결된 IVS 채널이 업습니다.")
+            raise HTTPException(404, "해당 세션에 연결된 IVS 채널이 없습니다.")
+
+        playback_token = None
+
+        # 채널이 비공개(Private) 설정이 되어 있다면 토큰을 발급합니다.
+        if channel.is_private:
+            playback_token = self.playback_provider.sign_playback_token(
+                channel_arn=channel.channel_arn,
+                viewer_id=f"admin-{user.id}",
+                duration_sec=3600,  # 1시간
+            )
 
         # AWS IVS 헬스체크(방송 중 아니면 None)
         stream_res = self.ivs_client.get_stream_health(channel.channel_arn)
@@ -255,5 +266,6 @@ class StreamAdminService:
                 value=channel.get_stream_key(),  # OBS 스트림 키 (복호화)
             ),
             playback_url=channel.playback_url,
+            playback_token=playback_token,
             live_metrics=live_metrics,
         )

--- a/app/domains/streams/deps.py
+++ b/app/domains/streams/deps.py
@@ -1,5 +1,10 @@
+from fastapi import Depends
+
+from app.api.deps import get_current_user_from_refresh_cookie
 from app.domains.streams.admin.service import StreamAdminService
 from app.domains.streams.client.service import StreamUserService
+from app.domains.streams.permissions import StreamPermission
+from app.domains.users.models import User
 from app.integrations.aws_ivs import IVSClient, IVSPlaybackProvider
 
 
@@ -22,3 +27,11 @@ def get_stream_user_service() -> StreamUserService:
         ivs_client=get_ivs_client(),  # 채널 조회용
         playback_provider=get_playback_provider(),  # 토큰 발행용
     )
+
+
+# 어드민 유저
+async def get_admin_user(
+    current_user: User = Depends(get_current_user_from_refresh_cookie),
+) -> User:
+    StreamPermission.must_be_admin(current_user)
+    return current_user

--- a/app/domains/streams/deps.py
+++ b/app/domains/streams/deps.py
@@ -16,17 +16,20 @@ def get_playback_provider() -> IVSPlaybackProvider:
     return IVSPlaybackProvider()
 
 
-# 1. Admin 전용 서비스 주입
-def get_stream_admin_service() -> StreamAdminService:
-    return StreamAdminService(ivs_client=get_ivs_client())
+# Admin 전용 서비스 주입
+def get_stream_admin_service(
+    ivs: IVSClient = Depends(get_ivs_client),
+    provider: IVSPlaybackProvider = Depends(get_playback_provider),
+) -> StreamAdminService:
+    return StreamAdminService(ivs_client=ivs, playback_provider=provider)
 
 
-# 2. User 전용 서비스 주입
-def get_stream_user_service() -> StreamUserService:
-    return StreamUserService(
-        ivs_client=get_ivs_client(),  # 채널 조회용
-        playback_provider=get_playback_provider(),  # 토큰 발행용
-    )
+# User 전용 서비스 주입
+def get_stream_user_service(
+    ivs: IVSClient = Depends(get_ivs_client),
+    provider: IVSPlaybackProvider = Depends(get_playback_provider),
+) -> StreamUserService:
+    return StreamUserService(ivs_client=ivs, playback_provider=provider)
 
 
 # 어드민 유저

--- a/templates/stream_monitor.html
+++ b/templates/stream_monitor.html
@@ -5,120 +5,216 @@
     <title>IVS 관리자 모니터링 - 세션 #{{ session_id }}</title>
     <script src="https://player.live-video.net/1.24.0/amazon-ivs-player.min.js"></script>
     <style>
-        body { font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; background: #0f0f0f; color: #f1f1f1; margin: 0; padding: 20px; }
-        .dashboard { display: grid; grid-template-columns: 400px 1fr; gap: 24px; max-width: 1600px; margin: 0 auto; }
-        .card { background: #1a1a1a; padding: 24px; border-radius: 12px; border: 1px solid #333; box-shadow: 0 4px 6px rgba(0,0,0,0.3); }
-        h1 { font-size: 24px; margin-bottom: 20px; border-bottom: 1px solid #333; padding-bottom: 10px; }
-        .badge { padding: 6px 14px; border-radius: 20px; font-weight: bold; font-size: 14px; text-transform: uppercase; }
+        body { font-family: 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; background: #0f0f0f; color: #f1f1f1; margin: 0; padding: 20px; }
+        .dashboard { display: grid; grid-template-columns: 420px 1fr; gap: 24px; max-width: 1600px; margin: 0 auto; }
+        .card { background: #1a1a1a; padding: 24px; border-radius: 12px; border: 1px solid #333; box-shadow: 0 4px 12px rgba(0,0,0,0.5); }
+
+        /* 헤더 영역 */
+        .header-bar { display: flex; justify-content: space-between; align-items: center; margin-bottom: 24px; border-bottom: 1px solid #333; padding-bottom: 15px; }
+        h1 { font-size: 22px; margin: 0; }
+        .logout-btn { background: #444; font-size: 12px; margin-left: 8px; color: #eee; border: none; padding: 8px 15px; border-radius: 4px; cursor: pointer; }
+
+        /* 상태 배지 */
+        .status-container { display: flex; justify-content: space-between; align-items: center; margin-bottom: 20px; background: #252525; padding: 12px; border-radius: 8px; }
+        .badge { padding: 6px 12px; border-radius: 4px; font-weight: bold; font-size: 12px; text-transform: uppercase; }
         .live { background: #e91916; color: white; animation: pulse 2s infinite; }
         .offline { background: #444; color: #aaa; }
-        @keyframes pulse { 0% { opacity: 1; } 50% { opacity: 0.7; } 100% { opacity: 1; } }
-        pre { background: #000; padding: 12px; color: #00e676; border-radius: 6px; font-size: 13px; white-space: pre-wrap; word-break: break-all; border: 1px solid #222; min-height: 20px; }
-        button { width: 100%; padding: 12px; background: #3f51b5; color: white; border: none; border-radius: 6px; cursor: pointer; font-weight: bold; transition: background 0.3s; }
-        button:hover { background: #303f9f; }
-        video { width: 100%; border-radius: 8px; background: #000; aspect-ratio: 16/9; box-shadow: 0 8px 16px rgba(0,0,0,0.5); }
-        .metric-item { margin: 10px 0; font-size: 15px; }
-        .error-msg { color: #ff4d4d; font-weight: bold; font-size: 14px; }
+        @keyframes pulse { 0% { opacity: 1; } 50% { opacity: 0.6; } 100% { opacity: 1; } }
+
+        /* 정보 텍스트 */
+        p { margin: 15px 0 5px 0; font-size: 14px; color: #aaa; font-weight: bold; }
+        pre { background: #000; padding: 12px; color: #00e676; border-radius: 6px; font-size: 13px; white-space: pre-wrap; word-break: break-all; border: 1px solid #222; margin: 0; }
+
+        /* 메트릭 영역 */
+        .metric-group { margin-top: 25px; border-top: 1px solid #333; padding-top: 20px; }
+        .metric-item { display: flex; justify-content: space-between; margin-bottom: 10px; font-size: 15px; }
+        .metric-label { color: #888; }
+
+        /* 비디오 플레이어 */
+        .video-container { position: relative; background: #000; border-radius: 8px; overflow: hidden; aspect-ratio: 16/9; }
+        video { width: 100%; height: 100%; display: block; }
+        .playback-info { margin-top: 15px; font-size: 13px; color: #777; display: flex; justify-content: space-between; }
+
+        button.primary { padding: 10px 20px; background: #3f51b5; color: white; border: none; border-radius: 6px; cursor: pointer; font-weight: bold; }
+        button.primary:hover { background: #303f9f; }
     </style>
 </head>
 <body>
-    <h1>세션 모니터링 <small style="color:#888;">#{{ session_id }}</small></h1>
+
+    <div class="header-bar">
+        <div >
+            <h1>세션 모니터링 <small style="color:#888;">#{{ session_id }}</small></h1>
+            <div id="concert-title" style="color: #58a6ff; font-weight: bold; margin-top: 5px;">불러오는 중...</div>
+        </div>
+        <div>
+            <button class="primary" onclick="refreshData()">즉시 갱신</button>
+        </div>
+    </div>
+
     <div class="dashboard">
         <div class="card">
-            <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 20px;">
-                <span id="badge" class="badge offline">LOADING...</span>
-                <button onclick="refreshData()" style="width: auto; padding: 6px 16px;">새로고침</button>
+            <div class="status-container">
+                <span id="badge" class="badge offline">AWS: OFFLINE</span>
+                <div style="text-align: right;">
+                    <small style="color: #888; display: block; font-size: 10px;">DB STATUS</small>
+                    <strong id="db-status" style="color: #f1f1f1;">-</strong>
+                </div>
             </div>
 
-            <div style="margin-bottom: 20px; padding: 10px; background: #252525; border-radius: 6px;">
-                <small style="color: #888;">System DB Status:</small>
-                <strong id="db-status" style="color: #58a6ff; margin-left: 5px;">-</strong>
-            </div>
-
-            <p><strong>Ingest Endpoint (OBS 서버)</strong></p>
+            <p>Ingest Endpoint</p>
             <pre id="endpoint">-</pre>
 
-            <p><strong>Stream Key (OBS 스트림 키)</strong></p>
-            <pre id="key">-</pre>
+            <p>Stream Key</p>
+            <pre id="key">********</pre>
 
-            <hr style="border: 0.5px solid #333; margin: 24px 0;">
-            <h3>실시간 메트릭 (AWS IVS)</h3>
-            <div id="metrics-content">데이터를 불러오는 중입니다...</div>
+            <div class="metric-group">
+                <h3>실시간 메트릭 (AWS IVS)</h3>
+                <div id="metrics-content">
+                    <div class="metric-item">
+                        <span class="metric-label">스트림 상태</span>
+                        <strong id="m-health">-</strong>
+                    </div>
+                    <div class="metric-item">
+                        <span class="metric-label">현재 시청자</span>
+                        <strong id="m-viewers">-</strong>
+                    </div>
+                    <div class="metric-item">
+                        <span class="metric-label">방송 시작 시간</span>
+                        <strong id="m-start">-</strong>
+                    </div>
+                </div>
+            </div>
         </div>
 
         <div class="card">
-            <video id="video-player" controls playsinline></video>
-            <div style="margin-top: 15px; font-size: 13px; color: #777;">
-                <strong>Playback URL:</strong> <span id="play-url">-</span>
+            <div class="video-container">
+                <video id="video-player" controls playsinline></video>
+            </div>
+            <div class="playback-info">
+                <span><strong>URL:</strong> <span id="play-url">-</span></span>
+                <span id="token-status" style="font-weight: bold;"></span>
+            </div>
+            <div style="margin-top: 20px; color: #555; font-size: 12px; line-height: 1.6;">
+                * 5초마다 데이터가 자동으로 동기화됩니다.<br>
+                * 비공개 채널인 경우 백엔드에서 발급된 Playback Token을 사용하여 재생합니다.
             </div>
         </div>
     </div>
 
     <script>
+        // 1. IVS 플레이어 초기화
         const player = IVSPlayer.create();
         player.attachTo(document.getElementById("video-player"));
+        player.setMuted(true); // 자동 재생 정책 준수
 
+        // 2. 인증 요청 래퍼
+        async function fetchWithAuth(url, options = {}) {
+            let token = localStorage.getItem("access_token");
+            options.headers = {
+                ...options.headers,
+                "Authorization": `Bearer ${token}`,
+                "Content-Type": "application/json"
+            };
+
+            let res = await fetch(url, options);
+
+            if (res.status === 401) {
+                const refreshRes = await fetch("/api/v1/auth/refresh", { method: "POST" });
+                if (refreshRes.ok) {
+                    const refreshData = await refreshRes.json();
+                    localStorage.setItem("access_token", refreshData.access_token);
+                    options.headers["Authorization"] = `Bearer ${refreshData.access_token}`;
+                    res = await fetch(url, options);
+                } else {
+                    window.location.href = "/login";
+                }
+            }
+            return res;
+        }
+
+        async function logout() {
+            await fetch("/api/v1/auth/logout", { method: "POST" });
+            localStorage.removeItem("access_token");
+            window.location.href = "/login";
+        }
+
+        // 3. 데이터 동기화
         async function refreshData() {
             try {
-                // 중요: 스웨거 로그인 후 받은 토큰을 브라우저 개발자 도구 콘솔에서 아래와 같이 입력해야 합니다.
-                // localStorage.setItem("token", "여기에_토큰_복사");
-                const token = localStorage.getItem("token") || localStorage.getItem("access_token");
-
-                if (!token) {
-                    document.getElementById("metrics-content").innerHTML =
-                        "<span class='error-msg'>인증 토큰이 없습니다. <br>콘솔에서 localStorage에 토큰을 설정해주세요.</span>";
-                    return;
-                }
-
-                const res = await fetch(`/api/v1/admin/streams/sessions/{{ session_id }}/ingest`, {
-                    headers: {
-                        "Authorization": `Bearer ${token}`,
-                        "Content-Type": "application/json"
-                    }
-                });
-
-                if (res.status === 401) {
-                    document.getElementById("metrics-content").innerHTML = "<span class='error-msg'>인증 실패 (401)</span>";
-                    return;
-                }
+                const res = await fetchWithAuth(`/api/v1/admin/streams/sessions/{{ session_id }}/ingest`);
+                if (!res || !res.ok) return;
 
                 const data = await res.json();
 
-                // 1. UI 업데이트
-                document.getElementById("db-status").innerText = data.status;
+                // [데이터 업데이트]
+                document.getElementById("concert-title").innerText = data.concertTitle || "제목 없음";
+                document.getElementById("db-status").innerText = data.status; // READY, LIVE, ENDED...
                 document.getElementById("endpoint").innerText = data.ingestInfo.ingestEndpoint;
                 document.getElementById("key").innerText = data.ingestInfo.value;
                 document.getElementById("play-url").innerText = data.playbackUrl;
 
                 const badge = document.getElementById("badge");
-                const metrics = document.getElementById("metrics-content");
+                const mHealth = document.getElementById("m-health");
+                const mViewers = document.getElementById("m-viewers");
+                const mStart = document.getElementById("m-start");
+                const tokenStatus = document.getElementById("token-status");
 
-                if (data.isLive && data.liveMetrics) {
-                    badge.innerText = "LIVE";
+                if (data.isLive) {
+                    // AWS 송출 중
+                    badge.innerText = "AWS: ON-AIR";
                     badge.className = "badge live";
-                    const m = data.liveMetrics;
-                    metrics.innerHTML = `
-                        <div class="metric-item">헬스: <strong style="color:${m.health === 'HEALTHY' ? '#39d353' : '#ff9800'}">${m.health}</strong></div>
-                        <div class="metric-item">시청자 수: <strong>${m.viewerCount.toLocaleString()}명</strong></div>
-                        <div class="metric-item">송출 시작: ${new Date(m.startTime).toLocaleString()}</div>
-                    `;
-                    if (player.getSrc() !== data.playbackUrl) {
-                        player.load(data.playbackUrl);
+
+                    if (data.liveMetrics) {
+                        mHealth.innerText = data.liveMetrics.health;
+                        mHealth.style.color = data.liveMetrics.health === 'HEALTHY' ? '#39d353' : '#ff9800';
+                        mViewers.innerText = data.liveMetrics.viewerCount.toLocaleString() + " 명";
+                        mStart.innerText = new Date(data.liveMetrics.startTime).toLocaleTimeString();
+                    }
+
+                    // [플레이어 토큰 처리]
+                    let finalUrl = data.playbackUrl;
+                    if (data.playbackToken) {
+                        finalUrl += `?token=${data.playbackToken}`;
+                        tokenStatus.innerText = "🔒 AUTHORIZED (PRIVATE)";
+                        tokenStatus.style.color = "#00e676";
+                    } else {
+                        tokenStatus.innerText = "🔓 PUBLIC";
+                        tokenStatus.style.color = "#888";
+                    }
+
+                    // 비디오 소스 로드 (중복 로드 방지)
+                    if (player.getSrc() !== finalUrl) {
+                        console.log("Stream Source Updated:", finalUrl);
+                        player.load(finalUrl);
                         player.play();
                     }
                 } else {
-                    badge.innerText = "OFFLINE";
+                    // AWS 송출 중단됨
+                    badge.innerText = "AWS: OFFLINE";
                     badge.className = "badge offline";
-                    metrics.innerText = "현재 실시간 송출 데이터가 없습니다.";
-                    if (player.getSrc()) player.pause();
+                    mHealth.innerText = "-";
+                    mViewers.innerText = "-";
+                    mStart.innerText = "-";
+                    tokenStatus.innerText = "";
+
+                    // 필요한 경우 방송 중단 시 플레이어 초기화
+                    // if (player.getSrc()) player.pause();
                 }
+
             } catch (err) {
-                console.error("Fetch error:", err);
+                console.error("Monitoring Update Failed:", err);
             }
         }
 
+        // 초기 로드 및 5초 간격 실행
         refreshData();
-        setInterval(refreshData, 10000);
+        const poll = setInterval(refreshData, 5000);
+
+        // 페이지를 떠날 때 리소스 해제
+        window.addEventListener('beforeunload', () => {
+            clearInterval(poll);
+            player.delete();
+        });
     </script>
 </body>
 </html>

--- a/tests/streams/admin/test_router.py
+++ b/tests/streams/admin/test_router.py
@@ -89,9 +89,9 @@ class TestStreamRouter:
                     start_at=datetime.now(),
                     channel=IVSChannelSummary(
                         arn="arn:test",
-                        ingestEndpoint="rtmps://test",
-                        playbackUrl="https://test.m3u8",
-                        latencyMode=LatencyMode.LOW,
+                        ingest_endpoint="rtmps://test",
+                        playback_url="https://test.m3u8",
+                        latency_mode=LatencyMode.LOW,
                         type=ChannelType.STANDARD,
                     ),
                     value="sk_test",
@@ -117,3 +117,130 @@ class TestStreamRouter:
 
         finally:
             app.dependency_overrides.clear()
+
+    class TestStreamRouterExtended:
+        """Router 커버리지 향상을 위한 추가 테스트"""
+
+        @pytest.fixture
+        async def client(self):
+            async with AsyncClient(
+                transport=ASGITransport(app=app),
+                base_url="http://test",
+            ) as ac:
+                yield ac
+
+        @pytest.fixture
+        def mock_admin_user(self):
+            user = MagicMock()
+            user.id = 1
+            user.is_admin = True
+            return user
+
+        @pytest.mark.asyncio
+        async def test_delete_concert_session_success(self, client, mock_admin_user):
+            """세션 삭제 엔드포인트 성공 케이스"""
+            app.dependency_overrides[get_current_user] = lambda: mock_admin_user
+
+            try:
+                with patch(
+                    "app.domains.streams.admin.service.StreamAdminService.delete_session_with_infrastructure",
+                    new_callable=AsyncMock,
+                ) as mock_delete:
+                    mock_delete.return_value = None
+
+                    res = await client.delete("/api/v1/admin/streams/sessions/1")
+                    assert res.status_code == 204
+                    mock_delete.assert_called_once()
+
+            finally:
+                app.dependency_overrides.clear()
+
+        @pytest.mark.asyncio
+        async def test_rotate_stream_key_success(self, client, mock_admin_user):
+            """스트림 키 재발급 엔드포인트 성공 케이스"""
+            app.dependency_overrides[get_current_user] = lambda: mock_admin_user
+
+            try:
+                with patch(
+                    "app.domains.streams.admin.service.StreamAdminService.rotate_stream_key",
+                    new_callable=AsyncMock,
+                ) as mock_rotate:
+                    mock_rotate.return_value = "new_sk_12345"
+
+                    res = await client.post("/api/v1/admin/streams/sessions/1/rotate-key")
+                    assert res.status_code == 200
+                    assert res.json()["value"] == "new_sk_12345"
+                    assert "재발급" in res.json()["message"]
+
+            finally:
+                app.dependency_overrides.clear()
+
+        @pytest.mark.asyncio
+        async def test_stop_live_stream_success(self, client, mock_admin_user):
+            """라이브 방송 강제 종료 엔드포인트 성공 케이스"""
+            app.dependency_overrides[get_current_user] = lambda: mock_admin_user
+
+            try:
+                with patch(
+                    "app.domains.streams.admin.service.StreamAdminService.stop_stream_session",
+                    new_callable=AsyncMock,
+                ) as mock_stop:
+                    mock_stop.return_value = None
+
+                    res = await client.post("/api/v1/admin/streams/sessions/1/stop")
+                    assert res.status_code == 200
+                    assert "종료" in res.json()["message"]
+
+            finally:
+                app.dependency_overrides.clear()
+
+        @pytest.mark.asyncio
+        async def test_get_session_ingest_data_success(self, client, mock_admin_user):
+            """송출 정보 조회 엔드포인트 성공 케이스"""
+            app.dependency_overrides[get_current_user] = lambda: mock_admin_user
+
+            try:
+                from app.domains.streams.admin.schemas import (
+                    StreamIngestInfo,
+                    StreamIngestResponse,
+                    StreamLiveMetrics,
+                )
+
+                mock_response = StreamIngestResponse(
+                    session_id=1,
+                    is_live=True,
+                    concert_title="Test Concert",
+                    ingest_info=StreamIngestInfo(
+                        ingest_endpoint="rtmps://test.com",
+                        value="sk_test",
+                    ),
+                    playback_url="https://test.m3u8",
+                    live_metrics=StreamLiveMetrics(
+                        health="HEALTHY",
+                        viewer_count=100,
+                        start_time=datetime.now(),
+                        state="LIVE",
+                    ),
+                )
+
+                with patch(
+                    "app.domains.streams.admin.service.StreamAdminService.get_stream_ingest_info",
+                    new_callable=AsyncMock,
+                ) as mock_ingest:
+                    mock_ingest.return_value = mock_response
+
+                    res = await client.get("/api/v1/admin/streams/sessions/1/ingest")
+                    assert res.status_code == 200
+                    data = res.json()
+                    assert data["isLive"] is True
+                    assert data["liveMetrics"]["viewerCount"] == 100
+
+            finally:
+                app.dependency_overrides.clear()
+
+        @pytest.mark.asyncio
+        async def test_stream_monitor_page(self, client):
+            """모니터링 페이지 HTML 응답 검증"""
+            res = await client.get("/api/v1/admin/streams/sessions/1/monitor")
+            assert res.status_code == 200
+            assert "text/html" in res.headers["content-type"]

--- a/tests/streams/admin/test_router.py
+++ b/tests/streams/admin/test_router.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from httpx import ASGITransport, AsyncClient
 
-from app.api.deps import get_current_user
+from app.domains.streams.deps import get_admin_user
 from app.domains.streams.models import AccessLevel, ChannelType, LatencyMode
 from app.main import app
 
@@ -41,7 +41,7 @@ class TestStreamRouter:
         async def override_get_current_user():
             return mock_admin_user
 
-        app.dependency_overrides[get_current_user] = override_get_current_user
+        app.dependency_overrides[get_admin_user] = override_get_current_user
 
         try:
             with (
@@ -139,7 +139,7 @@ class TestStreamRouter:
         @pytest.mark.asyncio
         async def test_delete_concert_session_success(self, client, mock_admin_user):
             """세션 삭제 엔드포인트 성공 케이스"""
-            app.dependency_overrides[get_current_user] = lambda: mock_admin_user
+            app.dependency_overrides[get_admin_user] = lambda: mock_admin_user
 
             try:
                 with patch(
@@ -158,7 +158,7 @@ class TestStreamRouter:
         @pytest.mark.asyncio
         async def test_rotate_stream_key_success(self, client, mock_admin_user):
             """스트림 키 재발급 엔드포인트 성공 케이스"""
-            app.dependency_overrides[get_current_user] = lambda: mock_admin_user
+            app.dependency_overrides[get_admin_user] = lambda: mock_admin_user
 
             try:
                 with patch(
@@ -178,7 +178,7 @@ class TestStreamRouter:
         @pytest.mark.asyncio
         async def test_stop_live_stream_success(self, client, mock_admin_user):
             """라이브 방송 강제 종료 엔드포인트 성공 케이스"""
-            app.dependency_overrides[get_current_user] = lambda: mock_admin_user
+            app.dependency_overrides[get_admin_user] = lambda: mock_admin_user
 
             try:
                 with patch(
@@ -197,7 +197,7 @@ class TestStreamRouter:
         @pytest.mark.asyncio
         async def test_get_session_ingest_data_success(self, client, mock_admin_user):
             """송출 정보 조회 엔드포인트 성공 케이스"""
-            app.dependency_overrides[get_current_user] = lambda: mock_admin_user
+            app.dependency_overrides[get_admin_user] = lambda: mock_admin_user
 
             try:
                 from app.domains.streams.admin.schemas import (
@@ -239,8 +239,13 @@ class TestStreamRouter:
                 app.dependency_overrides.clear()
 
         @pytest.mark.asyncio
-        async def test_stream_monitor_page(self, client):
+        async def test_stream_monitor_page(self, client, mock_admin_user):
             """모니터링 페이지 HTML 응답 검증"""
-            res = await client.get("/api/v1/admin/streams/sessions/1/monitor")
-            assert res.status_code == 200
-            assert "text/html" in res.headers["content-type"]
+            app.dependency_overrides[get_admin_user] = lambda: mock_admin_user
+
+            try:
+                res = await client.get("/api/v1/admin/streams/sessions/1/monitor")
+                assert res.status_code == 200
+                assert "text/html" in res.headers["content-type"]
+            finally:
+                app.dependency_overrides.clear()

--- a/tests/streams/admin/test_service.py
+++ b/tests/streams/admin/test_service.py
@@ -34,10 +34,18 @@ class TestStreamService:
         }
         return client
 
+    @pytest.fixture
+    def mock_playback_provider(self):
+        provider = MagicMock()
+        provider.sign_playback_token.return_value = "mock_playback_token_xyz"
+        return provider
+
     @pytest.mark.asyncio
-    async def test_admin_service_coverage(self, mock_ivs_client):
+    async def test_admin_service_coverage(self, mock_ivs_client, mock_playback_provider):
         """Admin 세션 생성 및 DB 에러 시 롤백 로직 검증"""
-        service = StreamAdminService(ivs_client=mock_ivs_client)
+        service = StreamAdminService(
+            ivs_client=mock_ivs_client, playback_provider=mock_playback_provider
+        )
         mock_user = MagicMock(is_admin=True)
 
         now = datetime.now()
@@ -101,12 +109,14 @@ class TestStreamService:
             mock_ivs_client.delete_channel.assert_called_with(mock_channel_inst.channel_arn)
 
     @pytest.mark.asyncio
-    async def test_admin_ivs_permission_denied(self, mock_ivs_client):
+    async def test_admin_ivs_permission_denied(self, mock_ivs_client, mock_playback_provider):
         """AWS IAM 권한 부족 에러 핸들링"""
         error_res = {"Error": {"Code": "AccessDeniedException", "Message": "Denied"}}
         mock_ivs_client.create_channel.side_effect = ClientError(error_res, "CreateChannel")
 
-        service = StreamAdminService(ivs_client=mock_ivs_client)
+        service = StreamAdminService(
+            ivs_client=mock_ivs_client, playback_provider=mock_playback_provider
+        )
         mock_user = MagicMock(is_admin=True)
 
         with (
@@ -128,9 +138,13 @@ class TestStreamService:
             assert "AWS 권한 부족" in exc.value.detail
 
     @pytest.mark.asyncio
-    async def test_get_stream_ingest_info_success_live(self, mock_ivs_client):
+    async def test_get_stream_ingest_info_success_live(
+        self, mock_ivs_client, mock_playback_provider
+    ):
         """방송 중일 때 송출 정보 조회 및 DB 상태 동기화 검증"""
-        service = StreamAdminService(ivs_client=mock_ivs_client)
+        service = StreamAdminService(
+            ivs_client=mock_ivs_client, playback_provider=mock_playback_provider
+        )
         mock_user = MagicMock(is_admin=True)
 
         # Mock 데이터 설정 (AWS IVS)
@@ -145,6 +159,7 @@ class TestStreamService:
 
         # DB 모델 Mocking
         mock_channel = MagicMock(spec=StreamChannel)
+        mock_channel.is_private = True
         mock_channel.channel_arn = "arn:aws:ivs:test"
         mock_channel.ingest_endpoint = "rtmps://test-ingest.com"
         mock_channel.playback_url = "https://test-play.com"
@@ -176,13 +191,17 @@ class TestStreamService:
             # 검증
             assert response.is_live is True
             assert response.live_metrics.viewer_count == 1500
+            assert response.playback_token == "mock_playback_token_xyz"
             assert mock_session.status == "LIVE"
             mock_session.save.assert_called_once()
+            mock_playback_provider.sign_playback_token.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_get_stream_ingest_info_no_channel(self, mock_ivs_client):
+    async def test_get_stream_ingest_info_no_channel(self, mock_ivs_client, mock_playback_provider):
         """세션에 IVS 채널이 연결되어 있지 않은 경우 404 검증"""
-        service = StreamAdminService(ivs_client=mock_ivs_client)
+        service = StreamAdminService(
+            ivs_client=mock_ivs_client, playback_provider=mock_playback_provider
+        )
         mock_user = MagicMock(is_admin=True)
 
         mock_session = MagicMock(spec=ConcertSession)
@@ -202,9 +221,13 @@ class TestStreamService:
             assert exc.value.status_code == 404
 
     @pytest.mark.asyncio
-    async def test_get_stream_ingest_info_permission_denied(self, mock_ivs_client):
+    async def test_get_stream_ingest_info_permission_denied(
+        self, mock_ivs_client, mock_playback_provider
+    ):
         """관리자 권한이 없을 때 예외 발생 검증"""
-        service = StreamAdminService(ivs_client=mock_ivs_client)
+        service = StreamAdminService(
+            ivs_client=mock_ivs_client, playback_provider=mock_playback_provider
+        )
         mock_user = MagicMock(is_admin=False)  # 일반 유저
 
         with patch(
@@ -217,9 +240,11 @@ class TestStreamService:
             assert exc.value.status_code == 403
 
     @pytest.mark.asyncio
-    async def test_rotate_stream_key_success(self, mock_ivs_client):
+    async def test_rotate_stream_key_success(self, mock_ivs_client, mock_playback_provider):
         """스트림 키 재발급 로직 검증 (기존 키 삭제 후 재생성)"""
-        service = StreamAdminService(ivs_client=mock_ivs_client)
+        service = StreamAdminService(
+            ivs_client=mock_ivs_client, playback_provider=mock_playback_provider
+        )
         mock_user = MagicMock(is_admin=True)
 
         # Mock 설정
@@ -252,9 +277,13 @@ class TestStreamService:
             mock_channel.save.assert_called_once_with(update_fields=["stream_key_encrypted"])
 
     @pytest.mark.asyncio
-    async def test_delete_session_with_infrastructure_success(self, mock_ivs_client):
+    async def test_delete_session_with_infrastructure_success(
+        self, mock_ivs_client, mock_playback_provider
+    ):
         """세션 및 IVS 인프라 삭제 로직 검증"""
-        service = StreamAdminService(ivs_client=mock_ivs_client)
+        service = StreamAdminService(
+            ivs_client=mock_ivs_client, playback_provider=mock_playback_provider
+        )
         mock_user = MagicMock(is_admin=True)
 
         mock_channel = MagicMock(spec=StreamChannel)
@@ -280,9 +309,11 @@ class TestStreamService:
             mock_session.delete.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_stop_stream_session_success(self, mock_ivs_client):
+    async def test_stop_stream_session_success(self, mock_ivs_client, mock_playback_provider):
         """라이브 강제 중단 및 상태 변경 검증"""
-        service = StreamAdminService(ivs_client=mock_ivs_client)
+        service = StreamAdminService(
+            ivs_client=mock_ivs_client, playback_provider=mock_playback_provider
+        )
         mock_user = MagicMock(is_admin=True)
 
         mock_channel = MagicMock(spec=StreamChannel)
@@ -309,9 +340,11 @@ class TestStreamService:
             mock_session.save.assert_called_once_with(update_fields=["status"])
 
     @pytest.mark.asyncio
-    async def test_create_session_artist_not_found(self, mock_ivs_client):
+    async def test_create_session_artist_not_found(self, mock_ivs_client, mock_playback_provider):
         """존재하지 않는 아티스트 ID 요청 시 400 에러 검증"""
-        service = StreamAdminService(ivs_client=mock_ivs_client)
+        service = StreamAdminService(
+            ivs_client=mock_ivs_client, playback_provider=mock_playback_provider
+        )
         mock_user = MagicMock(is_admin=True)
 
         session_data = SessionCreateRequest(
@@ -339,9 +372,13 @@ class TestStreamService:
             assert "존재하지 않는 아티스트" in exc.value.detail
 
     @pytest.mark.asyncio
-    async def test_delete_session_aws_failure_continues(self, mock_ivs_client):
+    async def test_delete_session_aws_failure_continues(
+        self, mock_ivs_client, mock_playback_provider
+    ):
         """AWS 채널 삭제 실패 시에도 DB 삭제는 진행되는지(Warning 로그) 검증"""
-        service = StreamAdminService(ivs_client=mock_ivs_client)
+        service = StreamAdminService(
+            ivs_client=mock_ivs_client, playback_provider=mock_playback_provider
+        )
         mock_user = MagicMock(is_admin=True)
 
         # AWS 삭제 시 에러 발생 시뮬레이션
@@ -368,9 +405,11 @@ class TestStreamService:
             mock_session.delete.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_stop_stream_aws_failure_continues(self, mock_ivs_client):
+    async def test_stop_stream_aws_failure_continues(self, mock_ivs_client, mock_playback_provider):
         """방송 중단 시 AWS 호출 에러가 나도 DB 상태는 변경되는지 검증"""
-        service = StreamAdminService(ivs_client=mock_ivs_client)
+        service = StreamAdminService(
+            ivs_client=mock_ivs_client, playback_provider=mock_playback_provider
+        )
         mock_user = MagicMock(is_admin=True)
 
         mock_ivs_client.stop_stream.side_effect = Exception("Already Stopped")

--- a/tests/streams/admin/test_service.py
+++ b/tests/streams/admin/test_service.py
@@ -16,6 +16,7 @@ from app.domains.streams.models import (
     ConcertSession,
     LatencyMode,
     StreamChannel,
+    StreamStatus,
 )
 
 
@@ -214,3 +215,183 @@ class TestStreamService:
                 await service.get_stream_ingest_info(1, mock_user)
 
             assert exc.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_rotate_stream_key_success(self, mock_ivs_client):
+        """스트림 키 재발급 로직 검증 (기존 키 삭제 후 재생성)"""
+        service = StreamAdminService(ivs_client=mock_ivs_client)
+        mock_user = MagicMock(is_admin=True)
+
+        # Mock 설정
+        mock_channel = MagicMock(spec=StreamChannel)
+        mock_channel.channel_arn = "arn:aws:ivs:test"
+        mock_channel.save = AsyncMock()
+
+        mock_session = MagicMock(spec=ConcertSession)
+        mock_session.stream_channel = mock_channel
+
+        # list_all_stream_keys 반환값 설정
+        mock_ivs_client.list_all_stream_keys.return_value = [{"arn": "old_key_arn"}]
+        mock_ivs_client.create_stream_key.return_value = {"streamKey": {"value": "new_secret_key"}}
+
+        with (
+            patch("app.domains.streams.admin.service.StreamPermission.must_be_admin"),
+            patch("app.domains.streams.models.ConcertSession.get") as mock_get,
+        ):
+            mock_query = MagicMock()
+            mock_query.prefetch_related = AsyncMock(return_value=mock_session)
+            mock_get.return_value = mock_query
+
+            # 실행
+            new_key = await service.rotate_stream_key(session_id=1, user=mock_user)
+
+            # 검증
+            assert new_key == "new_secret_key"
+            mock_ivs_client.delete_stream_key.assert_called_with("old_key_arn")
+            mock_channel.set_stream_key.assert_called_with("new_secret_key")
+            mock_channel.save.assert_called_once_with(update_fields=["stream_key_encrypted"])
+
+    @pytest.mark.asyncio
+    async def test_delete_session_with_infrastructure_success(self, mock_ivs_client):
+        """세션 및 IVS 인프라 삭제 로직 검증"""
+        service = StreamAdminService(ivs_client=mock_ivs_client)
+        mock_user = MagicMock(is_admin=True)
+
+        mock_channel = MagicMock(spec=StreamChannel)
+        mock_channel.channel_arn = "arn:aws:ivs:to-delete"
+
+        mock_session = MagicMock(spec=ConcertSession)
+        mock_session.stream_channel = mock_channel
+        mock_session.delete = AsyncMock()
+
+        with (
+            patch("app.domains.streams.admin.service.StreamPermission.must_be_admin"),
+            patch("app.domains.streams.models.ConcertSession.get_or_none") as mock_get_none,
+        ):
+            mock_query = MagicMock()
+            mock_query.prefetch_related = AsyncMock(return_value=mock_session)
+            mock_get_none.return_value = mock_query
+
+            # 실행
+            await service.delete_session_with_infrastructure(session_id=1, user=mock_user)
+
+            # 검증
+            mock_ivs_client.delete_channel.assert_called_with("arn:aws:ivs:to-delete")
+            mock_session.delete.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_stop_stream_session_success(self, mock_ivs_client):
+        """라이브 강제 중단 및 상태 변경 검증"""
+        service = StreamAdminService(ivs_client=mock_ivs_client)
+        mock_user = MagicMock(is_admin=True)
+
+        mock_channel = MagicMock(spec=StreamChannel)
+        mock_channel.channel_arn = "arn:aws:ivs:live-arn"
+
+        mock_session = MagicMock(spec=ConcertSession)
+        mock_session.stream_channel = mock_channel
+        mock_session.save = AsyncMock()
+
+        with (
+            patch("app.domains.streams.admin.service.StreamPermission.must_be_admin"),
+            patch("app.domains.streams.models.ConcertSession.get") as mock_get,
+        ):
+            mock_query = MagicMock()
+            mock_query.prefetch_related = AsyncMock(return_value=mock_session)
+            mock_get.return_value = mock_query
+
+            # 실행
+            await service.stop_stream_session(session_id=1, user=mock_user)
+
+            # 검증
+            mock_ivs_client.stop_stream.assert_called_with("arn:aws:ivs:live-arn")
+            assert mock_session.status == StreamStatus.ENDED
+            mock_session.save.assert_called_once_with(update_fields=["status"])
+
+    @pytest.mark.asyncio
+    async def test_create_session_artist_not_found(self, mock_ivs_client):
+        """존재하지 않는 아티스트 ID 요청 시 400 에러 검증"""
+        service = StreamAdminService(ivs_client=mock_ivs_client)
+        mock_user = MagicMock(is_admin=True)
+
+        session_data = SessionCreateRequest(
+            session_name="Session 1",
+            access_level=AccessLevel.PUBLIC,
+            start_at=datetime.now(),
+            channel_config=ChannelConfig(latency_mode=LatencyMode.LOW, type=ChannelType.STANDARD),
+            artist_ids=[1, 999],  # 999는 존재하지 않음
+        )
+
+        with (
+            patch("app.domains.streams.models.Concert.get", new_callable=AsyncMock),
+            patch("app.domains.streams.models.ConcertSession.create", new_callable=AsyncMock),
+            patch(
+                "app.domains.streams.admin.service.Artist.filter", new_callable=AsyncMock
+            ) as mock_art_filter,
+        ):
+            # DB에는 아티스트 1명만 있다고 가정
+            mock_art_filter.return_value = [MagicMock(id=1)]
+
+            with pytest.raises(HTTPException) as exc:
+                await service.create_session_with_infrastructure(1, session_data, mock_user)
+
+            assert exc.value.status_code == 400
+            assert "존재하지 않는 아티스트" in exc.value.detail
+
+    @pytest.mark.asyncio
+    async def test_delete_session_aws_failure_continues(self, mock_ivs_client):
+        """AWS 채널 삭제 실패 시에도 DB 삭제는 진행되는지(Warning 로그) 검증"""
+        service = StreamAdminService(ivs_client=mock_ivs_client)
+        mock_user = MagicMock(is_admin=True)
+
+        # AWS 삭제 시 에러 발생 시뮬레이션
+        mock_ivs_client.delete_channel.side_effect = Exception("AWS Delete Failed")
+
+        mock_session = MagicMock(spec=ConcertSession)
+        mock_session.stream_channel = MagicMock(channel_arn="arn:aws:ivs:error")
+        mock_session.delete = AsyncMock()
+
+        with (
+            patch("app.domains.streams.admin.service.StreamPermission.must_be_admin"),
+            patch("app.domains.streams.models.ConcertSession.get_or_none") as mock_get_none,
+            patch("app.domains.streams.admin.service.logger") as mock_logger,
+        ):
+            mock_query = MagicMock()
+            mock_query.prefetch_related = AsyncMock(return_value=mock_session)
+            mock_get_none.return_value = mock_query
+
+            # 실행
+            await service.delete_session_with_infrastructure(1, mock_user)
+
+            # 검증: AWS 에러가 났지만 DB 삭제는 호출되어야 함
+            mock_logger.warning.assert_called()
+            mock_session.delete.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_stop_stream_aws_failure_continues(self, mock_ivs_client):
+        """방송 중단 시 AWS 호출 에러가 나도 DB 상태는 변경되는지 검증"""
+        service = StreamAdminService(ivs_client=mock_ivs_client)
+        mock_user = MagicMock(is_admin=True)
+
+        mock_ivs_client.stop_stream.side_effect = Exception("Already Stopped")
+
+        mock_session = MagicMock(spec=ConcertSession)
+        mock_session.stream_channel = MagicMock(channel_arn="arn:aws:ivs:live")
+        mock_session.save = AsyncMock()
+
+        with (
+            patch("app.domains.streams.admin.service.StreamPermission.must_be_admin"),
+            patch("app.domains.streams.models.ConcertSession.get") as mock_get,
+            patch("app.domains.streams.admin.service.logger") as mock_logger,
+        ):
+            mock_query = MagicMock()
+            mock_query.prefetch_related = AsyncMock(return_value=mock_session)
+            mock_get.return_value = mock_query
+
+            # 실행
+            await service.stop_stream_session(1, mock_user)
+
+            # 검증: 에러 로그가 남고 상태는 ENDED로 바뀌어야 함
+            mock_logger.warning.assert_called()
+            assert mock_session.status == StreamStatus.ENDED
+            mock_session.save.assert_called_once()

--- a/tests/streams/client/test_router.py
+++ b/tests/streams/client/test_router.py
@@ -5,6 +5,7 @@ import pytest
 from httpx import ASGITransport, AsyncClient
 
 from app.api.deps import get_current_user
+from app.domains.streams.deps import get_admin_user
 from app.main import app
 
 
@@ -100,12 +101,8 @@ class TestStreamRouter:
 
     @pytest.mark.asyncio
     async def test_validation_error_handling(self, client, mock_admin_user):
-        """validation 에러: 422"""
-
-        async def override_get_current_user():
-            return mock_admin_user
-
-        app.dependency_overrides[get_current_user] = override_get_current_user
+        """인증은 통과시키고 데이터만 틀리게 보내서 422 확인"""
+        app.dependency_overrides[get_admin_user] = lambda: mock_admin_user
 
         try:
             # missing title

--- a/tests/streams/test_deps.py
+++ b/tests/streams/test_deps.py
@@ -1,3 +1,8 @@
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import HTTPException
+
 from app.domains.streams import deps
 
 
@@ -28,3 +33,31 @@ def test_get_stream_user_service():
     assert service is not None
     assert service.ivs_client is not None
     assert service.playback_provider is not None
+
+
+@pytest.mark.asyncio
+async def test_get_admin_user_success():
+    """어드민 유저 검증 성공 테스트"""
+    # Mock 유저 생성 (슈퍼유저 권한 부여)
+    mock_user = MagicMock()
+    mock_user.is_superuser = True
+
+    result = await deps.get_admin_user(current_user=mock_user)
+
+    assert result == mock_user
+    assert result.is_superuser is True
+
+
+@pytest.mark.asyncio
+async def test_get_admin_user_forbidden():
+    """일반 유저가 어드민 권한 요청 시 403 에러 테스트"""
+    # 일반 유저 Mock 생성
+    mock_user = MagicMock()
+    mock_user.is_superuser = False
+
+    # 실행 시 HTTPException(403)이 발생하는지 검증
+    with pytest.raises(HTTPException) as exc_info:
+        await deps.get_admin_user(current_user=mock_user)
+
+    assert exc_info.value.status_code == 403
+    assert "관리자만 접근이 가능합니다" in exc_info.value.detail


### PR DESCRIPTION
## ✅ PR 한줄 요약
- 강제종료, 세션삭제, 토큰재발급 추가

## 🔗 관련 이슈
- Jira: NEAR-83

## 🛠️ 변경 내용
- [x] 강제종료, 세션삭제, 토큰재발급 추가
- [x] admin 권한 라우터 단계에서 체크로 변경
- [x] 쿠키 방식으로 변경
- [x] 모니터링 프리뷰 안됨 일단 fix 시도는 해봄 (난 프론트가 아닌데)

## 🧪 테스트
- [x] 로컬 테스트 완료 (`uv run pytest -q`)
- [x] ruff/mypy 통과 확인
  - [x] `uv run ruff check .`
  - [x] `uv run ruff format --check .`
  - [x] `uv run mypy .`
