### PR TITLE
Near 90 stream list

### DIFF
--- a/app/core/pagination.py
+++ b/app/core/pagination.py
@@ -1,0 +1,32 @@
+from collections.abc import Sequence
+from typing import TypeVar
+
+from tortoise.queryset import QuerySet
+
+T = TypeVar("T")
+
+async def paginate_cursor(
+        queryset: QuerySet[T],
+        cursor: int | None,
+        limit: int,
+        cursor_field: str = "id",
+        order_by: str = "-id"
+) -> tuple[Sequence[T], int | None]:
+    """
+    범용 커서 페이지네이션 함수
+    """
+    # 커서 필터 적용
+    if cursor is not None:
+        is_desc = order_by.startswith("-")
+        op = "lt" if is_desc else "gt" # less than(<), greater than(>)
+        queryset = queryset.filter(**{f"{cursor_field}__{op}": cursor})
+
+    # limit + 1개를 조회하여 다음 페이지 존재 여부 확인
+    items = await queryset.order_by(order_by).limit(limit + 1)
+
+    has_next = len(items) > limit
+    items = items[:limit]
+
+    next_cursor = getattr(items[-1], cursor_field) if has_next and items else None
+
+    return items, next_cursor

--- a/app/core/pagination.py
+++ b/app/core/pagination.py
@@ -1,16 +1,15 @@
 from collections.abc import Sequence
-from typing import TypeVar
 
+from tortoise import Model
 from tortoise.queryset import QuerySet
 
-T = TypeVar("T")
 
-async def paginate_cursor(
-        queryset: QuerySet[T],
-        cursor: int | None,
-        limit: int,
-        cursor_field: str = "id",
-        order_by: str = "-id"
+async def paginate_cursor[T: Model](
+    queryset: QuerySet[T],
+    cursor: int | None,
+    limit: int,
+    cursor_field: str = "id",
+    order_by: str = "-id",
 ) -> tuple[Sequence[T], int | None]:
     """
     범용 커서 페이지네이션 함수
@@ -18,7 +17,7 @@ async def paginate_cursor(
     # 커서 필터 적용
     if cursor is not None:
         is_desc = order_by.startswith("-")
-        op = "lt" if is_desc else "gt" # less than(<), greater than(>)
+        op = "lt" if is_desc else "gt"  # less than(<), greater than(>)
         queryset = queryset.filter(**{f"{cursor_field}__{op}": cursor})
 
     # limit + 1개를 조회하여 다음 페이지 존재 여부 확인

--- a/app/domains/streams/client/router.py
+++ b/app/domains/streams/client/router.py
@@ -1,10 +1,14 @@
-from typing import Any
+from datetime import date
+from typing import Annotated, Any
 
 from fastapi import APIRouter, Body, Depends, Path
+from fastapi.params import Query
 
 from app.api import deps
 from app.domains.streams import deps as streams_deps
+from app.domains.streams.client.schemas import SessionItem, SessionListResponse
 from app.domains.streams.client.service import StreamUserService
+from app.domains.streams.models import CategoryType, StreamStatus
 from app.domains.users.models import User
 
 router = APIRouter(prefix="/streams", tags=["Streaming"])
@@ -49,4 +53,57 @@ async def refresh_stream_session(
         session_id,
         current_user,
         refresh_token,
+    )
+
+
+@router.get(
+    "/sessions",
+    response_model=SessionListResponse,
+    summary="스트리밍 목록 조회",
+)
+async def list_sessions(
+    status: StreamStatus | None = None,
+    category: CategoryType | None = None,
+    artist_name: str | None = None,
+    title: str | None = None,
+    from_date: Annotated[
+        date | None, Query(description="시작 날짜가 해당 날짜 이후 (YYYY-MM-DD)")
+    ] = None,
+    to_date: Annotated[
+        date | None, Query(description="종료 날짜가 해당 날짜까지 (YYYY-MM-DD)")
+    ] = None,
+    order_by: Annotated[
+        str, Query(description="정렬 순서: latest (최신순), oldest (과거순)")
+    ] = "latest",
+    cursor: Annotated[
+        int | None, Query(description="커서 페이지네이션용 기준 ID (이전 응답의 next_cursor)")
+    ] = None,
+    limit: Annotated[int, Query(ge=1, le=50, description="페이지당 조회 개수")] = 10,
+    service: StreamUserService = Depends(streams_deps.get_stream_user_service),
+) -> SessionListResponse:
+    items, next_cursor = await service.list_sessions(
+        status=status,
+        category=category,
+        artist_name=artist_name,
+        title=title,
+        from_date=from_date,
+        to_date=to_date,
+        order_by=order_by,
+        cursor=cursor,
+        limit=limit,
+    )
+
+    return SessionListResponse(
+        items=[
+            SessionItem.model_validate(
+                {
+                    **s.__dict__,
+                    "concert_title": s.concert.title,
+                    "thumbnail_url": s.concert.thumbnail_url,
+                    "category": s.concert.category,
+                }
+            )
+            for s in items
+        ],
+        next_cursor=next_cursor,
     )

--- a/app/domains/streams/client/router.py
+++ b/app/domains/streams/client/router.py
@@ -64,8 +64,10 @@ async def refresh_stream_session(
 async def list_sessions(
     status: StreamStatus | None = None,
     category: CategoryType | None = None,
-    artist_name: str | None = None,
-    title: str | None = None,
+    artist_name: Annotated[
+        str | None, Query(description="검색: 출연진 이름 (부분 검색 가능)")
+    ] = None,
+    title: Annotated[str | None, Query(description="검색: 공연 이름 (부분 검색 가능)")] = None,
     from_date: Annotated[
         date | None, Query(description="시작 날짜가 해당 날짜 이후 (YYYY-MM-DD)")
     ] = None,

--- a/app/domains/streams/client/schemas.py
+++ b/app/domains/streams/client/schemas.py
@@ -1,0 +1,26 @@
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict
+
+from app.domains.streams.models import CategoryType, StreamStatus
+
+
+class BaseSchema(BaseModel):
+    model_config = ConfigDict(populate_by_name=True, from_attributes=True)
+
+
+class SessionItem(BaseSchema):
+    """목록 조회 응답"""
+
+    id: int
+    concert_title: str
+    session_name: str
+    thumbnail_url: str | None
+    category: CategoryType
+    status: StreamStatus
+    start_at: datetime
+
+
+class SessionListResponse(BaseSchema):
+    items: list[SessionItem]
+    next_cursor: int | None

--- a/app/domains/streams/client/service.py
+++ b/app/domains/streams/client/service.py
@@ -1,9 +1,11 @@
+from collections.abc import Sequence
+from datetime import date, datetime, time
 from typing import Any
 
-from app.domains.streams.models import (
-    ConcertSession,
-    StreamChannel,
-)
+from tortoise.expressions import Q
+
+from app.core.pagination import paginate_cursor
+from app.domains.streams.models import CategoryType, ConcertSession, StreamChannel, StreamStatus
 from app.domains.streams.permissions import StreamPermission
 from app.domains.users.models import User
 from app.integrations.aws_ivs import IVSClient, IVSPlaybackProvider
@@ -75,3 +77,60 @@ class StreamUserService:
             "access_token": new_tokens["access_token"],
             "refresh_token": new_tokens["refresh_token"],
         }
+
+    async def list_sessions(
+        self,
+        status: StreamStatus | None = None,
+        category: CategoryType | None = None,
+        artist_name: str | None = None,
+        title: str | None = None,
+        from_date: date | None = None,
+        to_date: date | None = None,
+        order_by: str = "latest",
+        cursor: int | None = None,
+        limit: int = 10,
+    ) -> tuple[Sequence[ConcertSession], int | None]:
+        """
+        [User] 스트리밍 목록 조회 (커서 페이징)
+        - 상태, 카테고리(장르) 필터
+        - 제목 or 아티스트 검색
+        - 날짜 범위 필터
+        - 정렬 (latest / oldest)
+        """
+        # 필터링
+        filters = Q()
+        if status:  # 상태별
+            filters &= Q(status=status)
+        if category:  # 장르별
+            filters &= Q(concert__category=category)
+
+        if artist_name:
+            artist_name = artist_name.strip()
+            filters &= Q(lineup__stage_name__icontains=artist_name)
+
+        if title:
+            title = title.strip()
+            filters &= Q(concert__title__icontains=title)
+
+        if from_date:
+            filters &= Q(start_at__gte=from_date)
+
+        if to_date:
+            to_datetime = datetime.combine(to_date, time.max)
+            filters &= Q(start_at__lte=to_datetime)
+
+        queryset = (
+            ConcertSession.filter(filters)
+            .prefetch_related("concert", "lineup", "stream_channel")
+            .distinct()
+        )
+
+        # 정렬
+        order = "id" if order_by == "oldest" else "-id"
+
+        return await paginate_cursor(
+            queryset=queryset,
+            cursor=cursor,
+            limit=limit,
+            order_by=order,
+        )

--- a/app/domains/streams/models.py
+++ b/app/domains/streams/models.py
@@ -106,6 +106,8 @@ class ConcertSession(models.Model):
         "models.Artist",
         through="concert_artists",
         related_name="sessions",
+        forward_key="artist_id",
+        backward_key="session_id",
         description="이 공연에 참여하는 모든 출연진 목록",
     )
 

--- a/scripts/dev/seed_concert_session_and_channels.py
+++ b/scripts/dev/seed_concert_session_and_channels.py
@@ -1,0 +1,109 @@
+import asyncio
+from datetime import datetime, timedelta
+
+from tortoise import Tortoise
+
+from app.core.config import settings
+from app.core.tortoise_config import TORTOISE_ORM
+from app.domains.streams.models import (
+    AccessLevel,
+    ChannelType,
+    ConcertSession,
+    LatencyMode,
+    StreamChannel,
+    StreamStatus,
+)
+
+
+async def main() -> None:
+    await Tortoise.init(config=TORTOISE_ORM)
+
+    # 퍼블릭 엑세스 ============================================================
+    await ConcertSession.get_or_create(
+        id=1,
+        defaults={
+            "session_name": "mock_public",
+            "status": StreamStatus.READY,
+            "access_level": AccessLevel.PUBLIC,
+            "is_test": False,
+            "start_at": datetime.now() + timedelta(hours=5),
+            "end_at": datetime.now() + timedelta(hours=8),
+            "concert_id": 2,
+        },
+    )
+    await StreamChannel.get_or_create(
+        id=1,
+        defaults={
+            "type": ChannelType.STANDARD,
+            "latency_mode": LatencyMode.LOW,
+            "is_private": False,
+            "channel_arn": "arn:aws:ivs:ap-northeast-2:123456789012:channel/mock-channel-1",
+            "ingest_endpoint": "rtmps://mock.ingest.endpoint/app/",
+            "stream_key_encrypted": "mock_encrypted_stream_key",
+            "playback_url": "https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel.ism/.m3u8",
+            "session_id": 1,
+        },
+    )
+
+    # 특정 유저 엑세스 ============================================================
+    await ConcertSession.get_or_create(
+        id=2,
+        defaults={
+            "session_name": "mock_specific",
+            "status": StreamStatus.READY,
+            "access_level": AccessLevel.SPECIFIC,
+            "is_test": False,
+            "start_at": datetime.now() + timedelta(hours=5),
+            "end_at": datetime.now() + timedelta(hours=8),
+            "concert_id": 2,
+        },
+    )
+    await StreamChannel.get_or_create(
+        id=2,
+        defaults={
+            "type": ChannelType.STANDARD,
+            "latency_mode": LatencyMode.LOW,
+            "is_private": True,
+            "channel_arn": "arn:aws:ivs:ap-northeast-2:123456789012:channel/mock-channel-2",
+            "ingest_endpoint": "rtmps://mock.ingest.endpoint/app/",
+            "stream_key_encrypted": "mock_encrypted_stream_key",
+            "playback_url": "https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel.ism/.m3u8",
+            "session_id": 2,
+        },
+    )
+
+    # 어드민 온리 - 테스트 중 ============================================================
+    await ConcertSession.get_or_create(
+        id=3,
+        defaults={
+            "session_name": "mock_admin_only",
+            "status": StreamStatus.READY,
+            "access_level": AccessLevel.ADMIN_ONLY,
+            "is_test": True,
+            "start_at": datetime.now() + timedelta(hours=5),
+            "end_at": datetime.now() + timedelta(hours=8),
+            "concert_id": 2,
+        },
+    )
+
+    await StreamChannel.get_or_create(
+        id=3,
+        defaults={
+            "type": ChannelType.STANDARD,
+            "latency_mode": LatencyMode.LOW,
+            "is_private": True,
+            "channel_arn": "arn:aws:ivs:ap-northeast-2:123456789012:channel/mock-channel-3",
+            "ingest_endpoint": "rtmps://mock.ingest.endpoint/app/",
+            "stream_key_encrypted": "mock_encrypted_stream_key",
+            "playback_url": "https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel.ism/.m3u8",
+            "session_id": 3,
+        },
+    )
+
+    await Tortoise.close_connections()
+
+    print(f"[{settings.MODE}] 개발용 콘서트 세션 + 스트림 채널 생성 완료")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/dev/seed_stream_sessions.py
+++ b/scripts/dev/seed_stream_sessions.py
@@ -8,6 +8,7 @@ from app.core.tortoise_config import TORTOISE_ORM
 from app.domains.streams.models import (
     AccessLevel,
     ChannelType,
+    ConcertArtist,
     ConcertSession,
     LatencyMode,
     StreamChannel,
@@ -31,6 +32,21 @@ async def main() -> None:
             "concert_id": 2,
         },
     )
+    await ConcertArtist.get_or_create(
+        artist_id=1,
+        session_id=1,
+        defaults={
+            "is_admin": True,
+        },
+    )
+    await ConcertArtist.get_or_create(
+        artist_id=2,
+        session_id=1,
+        defaults={
+            "is_admin": False,
+        },
+    )
+
     await StreamChannel.get_or_create(
         id=1,
         defaults={
@@ -56,6 +72,13 @@ async def main() -> None:
             "start_at": datetime.now() + timedelta(hours=5),
             "end_at": datetime.now() + timedelta(hours=8),
             "concert_id": 2,
+        },
+    )
+    await ConcertArtist.get_or_create(
+        artist_id=3,
+        session_id=2,
+        defaults={
+            "is_admin": True,
         },
     )
     await StreamChannel.get_or_create(
@@ -85,7 +108,13 @@ async def main() -> None:
             "concert_id": 2,
         },
     )
-
+    await ConcertArtist.get_or_create(
+        artist_id=2,
+        session_id=3,
+        defaults={
+            "is_admin": True,
+        },
+    )
     await StreamChannel.get_or_create(
         id=3,
         defaults={

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,7 +30,8 @@ async def initialize_tests():
     """
     # 1. DB 초기화 (initializer 대신 Tortoise.init 사용으로 확실하게 연결)
     await Tortoise.init(
-        db_url="sqlite://:memory:", modules={"models": _CONFIG["apps"]["models"]["models"]}
+        db_url="sqlite://:memory:",
+        modules={"models": _CONFIG["apps"]["models"]["models"] + ["tests.core.test_pagination"]},
     )
 
     # 2. 스키마 생성

--- a/tests/core/test_pagination.py
+++ b/tests/core/test_pagination.py
@@ -1,0 +1,93 @@
+import pytest
+from tortoise import fields
+from tortoise.models import Model
+
+from app.core.pagination import paginate_cursor
+
+
+class TestItem(Model):
+    __test__ = False
+
+    id = fields.IntField(primary_key=True)
+    name = fields.CharField(max_length=50)
+
+    class Meta:
+        table = "test_items"
+        app = "models"
+
+
+@pytest.fixture
+async def sample_items():
+    await TestItem.all().delete()
+
+    items = [
+        await TestItem.create(name="a"),
+        await TestItem.create(name="b"),
+        await TestItem.create(name="c"),
+        await TestItem.create(name="d"),
+        await TestItem.create(name="e"),
+    ]
+    return items
+
+
+@pytest.mark.asyncio
+async def test_first_page_desc(sample_items):
+    queryset = TestItem.all()
+
+    items, next_cursor = await paginate_cursor(
+        queryset=queryset,
+        cursor=None,
+        limit=2,
+        order_by="-id",
+    )
+
+    assert [item.name for item in items] == ["e", "d"]
+    assert next_cursor == items[-1].id
+
+
+@pytest.mark.asyncio
+async def test_second_page_desc(sample_items):
+    queryset = TestItem.all()
+
+    first_items, cursor = await paginate_cursor(
+        queryset=queryset,
+        cursor=None,
+        limit=2,
+        order_by="-id",
+    )
+
+    second_items, next_cursor = await paginate_cursor(
+        queryset=queryset,
+        cursor=cursor,
+        limit=2,
+        order_by="-id",
+    )
+
+    assert [item.name for item in second_items] == ["c", "b"]
+    assert next_cursor == second_items[-1].id
+
+
+@pytest.mark.asyncio
+async def test_last_page_no_next_cursor(sample_items):
+    queryset = TestItem.all()
+
+    _, cursor = await paginate_cursor(queryset, None, limit=4, order_by="-id")
+    items, next_cursor = await paginate_cursor(queryset, cursor, limit=4, order_by="-id")
+
+    assert len(items) == 1
+    assert next_cursor is None
+
+
+@pytest.mark.asyncio
+async def test_asc_order(sample_items):
+    queryset = TestItem.all()
+
+    items, next_cursor = await paginate_cursor(
+        queryset=queryset,
+        cursor=None,
+        limit=3,
+        order_by="id",
+    )
+
+    assert [item.name for item in items] == ["a", "b", "c"]
+    assert next_cursor == items[-1].id

--- a/tests/streams/client/test_router.py
+++ b/tests/streams/client/test_router.py
@@ -1,131 +1,82 @@
 from datetime import datetime
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from httpx import ASGITransport, AsyncClient
 
-from app.api.deps import get_current_user
-from app.domains.streams.deps import get_admin_user
+from app.api import deps
+from app.domains.streams import deps as streams_deps
 from app.main import app
 
 
+@pytest.mark.asyncio
 class TestStreamRouter:
     @pytest.fixture
-    async def client(self):
-        async with AsyncClient(
-            transport=ASGITransport(app=app),
-            base_url="http://test",
-        ) as ac:
-            yield ac
-
-    @pytest.fixture
-    def mock_admin_user(self):
-        """관리자 권한"""
-        user = MagicMock()
+    def mock_user(self):
+        user = AsyncMock()
         user.id = 1
-        user.is_admin = True
         return user
 
-    @pytest.fixture
-    def mock_regular_user(self):
-        """일반 사용자 권한"""
-        user = MagicMock()
-        user.id = 2
-        user.is_admin = False
-        return user
-
-    @pytest.mark.asyncio
-    async def test_user_router_get_credentials(self, client, mock_regular_user):
-        """일반 사용자가 스트림 세션에 대한 시청 자격 및 토큰을 정상적으로 발급받는지 검증"""
-
-        async def override_get_current_user():
-            return mock_regular_user
-
-        app.dependency_overrides[get_current_user] = override_get_current_user
-
+    async def test_get_stream_access_endpoint(self, client, mock_user):
+        app.dependency_overrides[deps.get_current_user] = lambda: mock_user
+        mock_service = AsyncMock()
+        mock_service.get_viewing_credentials.return_value = {"playback_url": "test"}
+        app.dependency_overrides[streams_deps.get_stream_user_service] = lambda: mock_service
         try:
-            with patch(
-                "app.domains.streams.client.service.StreamUserService.get_viewing_credentials",
-                new_callable=AsyncMock,
-            ) as mock_get_credentials:
-                mock_get_credentials.return_value = {
-                    "playback_url": "https://test.m3u8",
-                    "stream_id": 100,
-                    "access_token": "access",
-                    "refresh_token": "refresh",
-                }
-
-                res = await client.get("/api/v1/streams/sessions/10/credentials")
-
-                assert res.status_code == 200
-                assert res.json()["stream_id"] == 100
-
+            res = await client.get("/api/v1/streams/sessions/1/credentials")
+            assert res.status_code == 200
         finally:
             app.dependency_overrides.clear()
 
-    @pytest.mark.asyncio
-    async def test_user_router_refresh_session(self, client, mock_regular_user):
-        """일반 사용자가 기존 refresh token으로 시청 세션 연장, 새 토큰 발급받는지 검증"""
-
-        async def override_get_current_user():
-            return mock_regular_user
-
-        app.dependency_overrides[get_current_user] = override_get_current_user
-
+    async def test_refresh_stream_session_endpoint(self, client, mock_user):
+        app.dependency_overrides[deps.get_current_user] = lambda: mock_user
+        mock_service = AsyncMock()
+        mock_service.refresh_viewing_session.return_value = {"access_token": "new"}
+        app.dependency_overrides[streams_deps.get_stream_user_service] = lambda: mock_service
         try:
-            with patch(
-                "app.domains.streams.client.service.StreamUserService.refresh_viewing_session",
-                new_callable=AsyncMock,
-            ) as mock_refresh:
-                mock_refresh.return_value = {
-                    "access_token": "new_access",
-                    "refresh_token": "new_refresh",
-                    "playback_url": "https://test.m3u8",
-                }
-
-                res = await client.post(
-                    "/api/v1/streams/sessions/10/refresh",
-                    json={"refresh_token": "old"},
-                )
-
-                assert res.status_code == 200
-
-                mock_refresh.assert_called_once_with(
-                    10,
-                    mock_regular_user,
-                    "old",
-                )
-
-        finally:
-            app.dependency_overrides.clear()
-
-    @pytest.mark.asyncio
-    async def test_validation_error_handling(self, client, mock_admin_user):
-        """인증은 통과시키고 데이터만 틀리게 보내서 422 확인"""
-        app.dependency_overrides[get_admin_user] = lambda: mock_admin_user
-
-        try:
-            # missing title
             res = await client.post(
-                "/api/v1/admin/streams/concerts",
-                json={"description": "missing title"},
+                "/api/v1/streams/sessions/1/refresh", json={"refresh_token": "old"}
             )
-            assert res.status_code == 422
-
-            # invalid enum
-            res = await client.post(
-                "/api/v1/admin/streams/concerts/1/sessions",
-                json={
-                    "session_name": "Session",
-                    "access_level": "INVALID",
-                    "start_at": datetime.now().isoformat(),
-                    "channel_config": {
-                        "latency_mode": "LOW",
-                        "channel_type": "STANDARD",
-                    },
-                },
-            )
-            assert res.status_code == 422
-
+            assert res.status_code == 200
         finally:
             app.dependency_overrides.clear()
+
+    async def test_list_sessions_router_mapping(self, client, mock_user):
+        """GET /sessions 데이터 변환 검증 (커버리지 84-96 라인)"""
+        app.dependency_overrides[deps.get_current_user] = lambda: mock_user
+
+        # Mock 구성 (AttributeError 방지)
+        mock_session = MagicMock()
+        mock_session.id = 10
+        mock_session.session_name = "Real Session"
+        mock_session.status = "LIVE"
+        mock_session.start_at = datetime.now()
+
+        # 중첩된 객체(concert) 속성 설정
+        mock_session.concert.title = "Mapped Title"
+        mock_session.concert.thumbnail_url = "https://thumb.png"
+        mock_session.concert.category = "K-POP"
+
+        # router.py의 s.__dict__ 사용 부분 대응
+        mock_session.__dict__ = {
+            "id": 10,
+            "session_name": "Real Session",
+            "status": "LIVE",
+            "start_at": mock_session.start_at,
+            "concert": mock_session.concert,  # concert 객체도 포함
+        }
+
+        mock_service = AsyncMock()
+        mock_service.list_sessions.return_value = ([mock_session], 11)
+        app.dependency_overrides[streams_deps.get_stream_user_service] = lambda: mock_service
+
+        try:
+            res = await client.get("/api/v1/streams/sessions", params={"limit": 5})
+            assert res.status_code == 200
+            data = res.json()
+            assert data["items"][0]["concert_title"] == "Mapped Title"
+        finally:
+            app.dependency_overrides.clear()
+
+    async def test_list_sessions_validation_error(self, client):
+        res = await client.get("/api/v1/streams/sessions", params={"limit": 0})
+        assert res.status_code == 422

--- a/tests/streams/client/test_service.py
+++ b/tests/streams/client/test_service.py
@@ -1,108 +1,107 @@
+from datetime import date, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from app.domains.streams.client.service import StreamUserService
 from app.domains.streams.models import (
+    CategoryType,
+    Concert,
     ConcertSession,
     StreamChannel,
+    StreamStatus,
 )
 
 
+@pytest.mark.asyncio
 class TestStreamService:
     @pytest.fixture
-    def mock_ivs_client(self):
-        client = MagicMock()
-        client.create_channel.return_value = {
-            "channel": {
-                "arn": "arn:aws:ivs:region:account:channel/test-channel",
-                "ingestEndpoint": "rtmps://test.ingest.net/app/",
-                "playbackUrl": "https://test.playback.net/index.m3u8",
-            },
-            "streamKey": {"value": "sk_test_12345"},
-        }
-        return client
+    def mock_pb(self):
+        pb = MagicMock()
+        pb.sign_playback_token.return_value = "signed_token"
+        pb.sign_internal_tokens.return_value = {"access_token": "at", "refresh_token": "rt"}
+        pb.rotate_tokens.return_value = {"access_token": "new_at", "refresh_token": "new_rt"}
+        return pb
 
-    @pytest.mark.asyncio
-    async def test_user_service_viewing_flow(self):
-        """User 시청 권한 및 토큰 발급 로직 검증"""
-        mock_pb = MagicMock()
-        mock_pb.sign_playback_token.return_value = "token_abc"
-        mock_pb.sign_internal_tokens.return_value = {"access_token": "at", "refresh_token": "rt"}
+    @pytest.fixture
+    def service(self, mock_pb):
+        return StreamUserService(ivs_client=MagicMock(), playback_provider=mock_pb)
 
-        service = StreamUserService(ivs_client=MagicMock(), playback_provider=mock_pb)
+    async def test_get_viewing_credentials_logic(self, service, mock_pb):
+        """시청 권한 발급 및 공개/비공개 분기 검증"""
+        concert = await Concert.create(title="Test Concert", category=CategoryType.KPOP)
+        session = await ConcertSession.create(
+            concert=concert,
+            session_name="Session",
+            status=StreamStatus.LIVE,
+            start_at=datetime.now(),
+        )
+        channel = await StreamChannel.create(
+            id=session.id,
+            session=session,
+            playback_url="https://play.m3u8",
+            channel_arn="arn:ivs:test",
+            ingest_endpoint="https://ingest.com",
+            stream_key_encrypted="test_encrypted_key",
+            is_private=True,
+        )
+
         mock_user = MagicMock(id=1)
-
-        # 비공개 채널용 Mock
-        mock_channel = MagicMock(spec=StreamChannel)
-        mock_channel.id = 100
-        mock_channel.is_private = True
-        mock_channel.channel_arn = "arn:ivs:private"
-        mock_channel.playback_url = "https://play.m3u8"
-
-        mock_session = MagicMock(spec=ConcertSession)
-        mock_session.stream_channel = mock_channel
-
-        with (
-            patch("app.domains.streams.models.ConcertSession.get") as mock_get,
-            patch(
-                "app.domains.streams.permissions.StreamPermission.verify_playback_access",
-                new_callable=AsyncMock,
-            ),
+        with patch(
+            "app.domains.streams.permissions.StreamPermission.verify_playback_access",
+            new_callable=AsyncMock,
         ):
-            # Prefetch 결과 설정
-            mock_get.return_value.prefetch_related = AsyncMock(return_value=mock_session)
+            res = await service.get_viewing_credentials(session.id, mock_user)
+            assert "token=signed_token" in res["playback_url"]
 
-            # 실행 및 검증
-            res = await service.get_viewing_credentials(10, mock_user)
-            assert "token=token_abc" in res["playback_url"]
-            assert res["stream_id"] == 100
+            channel.is_private = False
+            await channel.save()
+            res_pub = await service.get_viewing_credentials(session.id, mock_user)
+            assert "token=" not in res_pub["playback_url"]
 
-            # 공개 채널 분기 테스트 (is_private=False)
-            mock_channel.is_private = False
-            res_public = await service.get_viewing_credentials(10, mock_user)
-            assert "token=" not in res_public["playback_url"]
+    async def test_refresh_viewing_session_full(self, service, mock_pb):
+        """시청 세션 연장"""
+        concert = await Concert.create(title="Refresh Test")
+        session = await ConcertSession.create(
+            concert=concert, session_name="S1", start_at=datetime.now()
+        )
+        await StreamChannel.create(
+            id=session.id,
+            session=session,
+            playback_url="https://test.com",
+            channel_arn="arn:ivs:test2",
+            ingest_endpoint="https://ingest2.com",
+            stream_key_encrypted="test_encrypted_key2",
+            is_private=True,
+        )
 
-    @pytest.mark.asyncio
-    async def test_user_service_refresh_tokens(self):
-        """User 시청 세션 토큰 갱신 테스트"""
-
-        # Mock PlaybackProvider 설정
-        mock_pb = MagicMock()
-        mock_pb.rotate_tokens.return_value = {"access_token": "new_at", "refresh_token": "new_rt"}
-        mock_pb.sign_playback_token.return_value = "new_token"
-
-        # 테스트 대상 서비스 생성
-        service = StreamUserService(ivs_client=MagicMock(), playback_provider=mock_pb)
         mock_user = MagicMock(id=1)
-
-        # 비공개 채널용 StreamChannel Mock
-        mock_channel = MagicMock(spec=StreamChannel)
-        mock_channel.id = 101
-        mock_channel.is_private = True
-        mock_channel.channel_arn = "arn:ivs:private"
-        mock_channel.playback_url = "https://play.m3u8"
-
-        # 세션에 채널 연결
-        mock_session = MagicMock(spec=ConcertSession)
-        mock_session.stream_channel = mock_channel
-
-        # ConcertSession.get() + prefetch_related Mock
-        with (
-            patch("app.domains.streams.models.ConcertSession.get") as mock_get,
-            patch(
-                "app.domains.streams.permissions.StreamPermission.verify_playback_access",
-                new_callable=AsyncMock,
-            ),
+        with patch(
+            "app.domains.streams.permissions.StreamPermission.verify_playback_access",
+            new_callable=AsyncMock,
         ):
-            mock_get.return_value.prefetch_related = AsyncMock(return_value=mock_session)
-
-            # 실제 테스트 실행
-            res = await service.refresh_viewing_session(10, mock_user, "old_rt")
-
-            # 검증: 토큰 갱신 결과 확인
+            res = await service.refresh_viewing_session(session.id, mock_user, "old_rt")
             assert res["access_token"] == "new_at"
-            assert res["refresh_token"] == "new_rt"
+            assert "token=signed_token" in res["playback_url"]
 
-            # 검증: 비공개 채널 URL에 서명 토큰 포함
-            assert "token=new_token" in res["playback_url"]
+    async def test_list_sessions_all_filters(self, service):
+        """목록 조회 필터링 검증"""
+        c1 = await Concert.create(title="AAA Concert", category=CategoryType.KPOP)
+        c2 = await Concert.create(title="BBB Show", category=CategoryType.TROT)
+
+        await ConcertSession.create(
+            concert=c1,
+            session_name="S1",
+            status=StreamStatus.ENDED,
+            start_at=datetime.now() - timedelta(days=1),
+        )
+        await ConcertSession.create(
+            concert=c2, session_name="S2", status=StreamStatus.LIVE, start_at=datetime.now()
+        )
+
+        assert len((await service.list_sessions(status=StreamStatus.LIVE))[0]) == 1
+        assert len((await service.list_sessions(category=CategoryType.KPOP))[0]) == 1
+        assert len((await service.list_sessions(title="BBB"))[0]) == 1
+
+        today = date.today()
+        assert len((await service.list_sessions(from_date=today, to_date=today))[0]) == 1


### PR DESCRIPTION
## ✅ PR 한줄 요약
-  커서 기반 페이지네이션과 아티스트 필터가 포함된 스트리밍 목록 조회 API 구현 및 테스트 데이터 생성

## 🔗 관련 이슈
- Jira: NEAR-90

## 🛠️ 변경 내용
- [x] add cursor-based pagination
- [x] add mock concert sessions, channels, and concert artists script
- [x] add streaming list api

## 🧪 테스트
- [x] 로컬 테스트 완료 (`uv run pytest -q`)
- [x] ruff/mypy 통과 확인
  - [x] `uv run ruff check .`
  - [x] `uv run ruff format --check .`
  - [x] `uv run mypy .`
