### PR TITLE
Near 91 get concert detail

### DIFF
--- a/app/domains/streams/client/router.py
+++ b/app/domains/streams/client/router.py
@@ -124,3 +124,11 @@ async def get_session_detail(
     service: StreamUserService = Depends(streams_deps.get_stream_user_service),
 ) -> SessionDetailResponse:
     return await service.get_sessions_detail(current_user, session_id)
+
+
+@router.get("/sessions/{session_id}/status", summary="실시간 스트리밍 상태")
+async def get_session_status(
+    session_id: int = Path(..., description="콘서트 세션 ID"),
+    service: StreamUserService = Depends(streams_deps.get_stream_user_service),
+) -> StreamStatus:
+    return await service.get_status(session_id)

--- a/app/domains/streams/client/router.py
+++ b/app/domains/streams/client/router.py
@@ -6,7 +6,11 @@ from fastapi.params import Query
 
 from app.api import deps
 from app.domains.streams import deps as streams_deps
-from app.domains.streams.client.schemas import SessionItem, SessionListResponse
+from app.domains.streams.client.schemas import (
+    SessionDetailResponse,
+    SessionItem,
+    SessionListResponse,
+)
 from app.domains.streams.client.service import StreamUserService
 from app.domains.streams.models import CategoryType, StreamStatus
 from app.domains.users.models import User
@@ -109,3 +113,14 @@ async def list_sessions(
         ],
         next_cursor=next_cursor,
     )
+
+
+@router.get(
+    "/sessions/{session_id}", response_model=SessionDetailResponse, summary="공연 상세 정보 조회"
+)
+async def get_session_detail(
+    session_id: int = Path(..., description="콘서트 세션 ID"),
+    current_user: User = Depends(deps.get_current_user),
+    service: StreamUserService = Depends(streams_deps.get_stream_user_service),
+) -> SessionDetailResponse:
+    return await service.get_sessions_detail(current_user, session_id)

--- a/app/domains/streams/client/schemas.py
+++ b/app/domains/streams/client/schemas.py
@@ -2,6 +2,7 @@ from datetime import datetime
 
 from pydantic import BaseModel, ConfigDict
 
+from app.domains.artists.models import GroupType
 from app.domains.streams.models import CategoryType, StreamStatus
 
 
@@ -24,3 +25,27 @@ class SessionItem(BaseSchema):
 class SessionListResponse(BaseSchema):
     items: list[SessionItem]
     next_cursor: int | None
+
+
+class ArtistItem(BaseSchema):
+    id: int
+    name: str
+    type: GroupType
+    profile_img_url: str | None
+    agency: str | None
+    is_main: bool
+
+
+class SessionDetailResponse(BaseSchema):
+    """상세조회 응답"""
+
+    id: int
+    concert_title: str
+    session_name: str
+    thumbnail_url: str | None
+    category: CategoryType
+    status: StreamStatus
+    description: str | None
+    lineup: list[ArtistItem]
+    start_at: datetime
+    end_at: datetime

--- a/app/domains/streams/client/service.py
+++ b/app/domains/streams/client/service.py
@@ -181,3 +181,9 @@ class StreamUserService:
             start_at=session.start_at,
             end_at=session.end_at,
         )
+
+    async def get_status(self, session_id: int) -> StreamStatus:
+        session = await ConcertSession.get_or_none(id=session_id)
+        if not session:
+            raise HTTPException(404, "콘서트 세션 정보를 찾을 수 없습니다.")
+        return session.status

--- a/app/domains/streams/client/service.py
+++ b/app/domains/streams/client/service.py
@@ -2,9 +2,14 @@ from collections.abc import Sequence
 from datetime import date, datetime, time
 from typing import Any
 
+from fastapi.exceptions import HTTPException
 from tortoise.expressions import Q
 
 from app.core.pagination import paginate_cursor
+from app.domains.streams.client.schemas import (
+    ArtistItem,
+    SessionDetailResponse,
+)
 from app.domains.streams.models import CategoryType, ConcertSession, StreamChannel, StreamStatus
 from app.domains.streams.permissions import StreamPermission
 from app.domains.users.models import User
@@ -20,8 +25,10 @@ class StreamUserService:
         """
         [User] 시청 권한 확인 및 최초 재생/채팅 토큰 발급
         """
-        session = await ConcertSession.get(id=session_id).prefetch_related("stream_channel")
+        session = await ConcertSession.get_or_none(id=session_id).prefetch_related("stream_channel")
 
+        if not session:
+            raise HTTPException(404, "콘서트 세션 정보를 찾을 수 없습니다.")
         # 유저 권한 증명
         await StreamPermission.verify_playback_access(user, session)
 
@@ -54,13 +61,18 @@ class StreamUserService:
         [User] 시청 중인 세션 연장 (아마존 권장: 연장 시마다 권한 재검증)
         """
         # 대상 세션, 채널 조회
-        session = await ConcertSession.get(id=session_id).prefetch_related("stream_channel")
+        session = await ConcertSession.get_or_none(id=session_id).prefetch_related("stream_channel")
 
-        # 갱신 시점에 다시 권한 체크
-        await StreamPermission.verify_playback_access(user, session)
+        if not session:
+            raise HTTPException(404, "콘서트 세션 정보를 찾을 수 없습니다.")
 
-        # 기존 리프레시 토큰으로 새 토큰 Access/Refresh 발급
-        new_tokens = self.playback_provider.rotate_tokens(refresh_token)
+        try:
+            # 갱신 시점에 다시 권한 체크
+            await StreamPermission.verify_playback_access(user, session)
+            # 기존 리프레시 토큰으로 새 토큰 Access/Refresh 발급
+            new_tokens = self.playback_provider.rotate_tokens(refresh_token)
+        except Exception:
+            raise HTTPException(401, "유효하지 않거나 만료된 리프레시 토큰입니다.") from None
 
         # IVS 재생 토큰 새 유효기간으로 재서명
         channel: StreamChannel = session.stream_channel
@@ -133,4 +145,39 @@ class StreamUserService:
             cursor=cursor,
             limit=limit,
             order_by=order,
+        )
+
+    async def get_sessions_detail(self, user: User, session_id: int) -> SessionDetailResponse:
+        session = await ConcertSession.get_or_none(id=session_id).prefetch_related(
+            "concert", "artist_mappings__artist"
+        )
+
+        if not session:
+            raise HTTPException(404, "공연 정보를 찾을 수 없습니다.")
+
+        await StreamPermission.verify_playback_access(user, session)
+
+        lineup_items = [
+            ArtistItem(
+                id=m.artist.id,
+                name=m.artist.stage_name,
+                type=m.artist.group_type,
+                profile_img_url=m.artist.profile_img_url,
+                agency=m.artist.agency,
+                is_main=m.is_main,
+            )
+            for m in session.artist_mappings
+        ]
+
+        return SessionDetailResponse(
+            id=session.id,
+            concert_title=session.concert.title,
+            session_name=session.session_name,
+            thumbnail_url=session.concert.thumbnail_url,
+            category=session.concert.category,
+            status=session.status,
+            description=session.concert.description,
+            lineup=lineup_items,
+            start_at=session.start_at,
+            end_at=session.end_at,
         )

--- a/app/domains/streams/models.py
+++ b/app/domains/streams/models.py
@@ -3,7 +3,12 @@ from typing import TYPE_CHECKING
 
 from cryptography.fernet import Fernet
 from tortoise import fields, models
-from tortoise.fields import ForeignKeyRelation, ManyToManyRelation, OneToOneRelation
+from tortoise.fields import (
+    ForeignKeyRelation,
+    ManyToManyRelation,
+    OneToOneRelation,
+    ReverseRelation,
+)
 
 from app.core.config import settings
 
@@ -132,7 +137,7 @@ class ConcertSession(models.Model):
 
     if TYPE_CHECKING:
         stream_channel: "StreamChannel"
-        artist_mappings: ForeignKeyRelation["ConcertArtist"]
+        artist_mappings: ReverseRelation["ConcertArtist"]
         stream_sessions: ForeignKeyRelation["StreamSession"]
         vods: ForeignKeyRelation["StreamVod"]
         scheduled_notis: fields.ReverseRelation["ConcertNoti"]

--- a/tests/streams/client/test_router.py
+++ b/tests/streams/client/test_router.py
@@ -140,3 +140,20 @@ class TestStreamRouter:
             assert data["lineup"][0]["name"] == "ArtistX"
         finally:
             app.dependency_overrides.clear()
+
+    @pytest.mark.asyncio
+    class TestStreamRouter:
+        async def test_get_status_endpoint(self, client):
+            """상태 조회 검증"""
+            # AsyncMock으로 상태 반환
+            mock_service = AsyncMock()
+            mock_service.get_status.return_value = "LIVE"
+
+            app.dependency_overrides[streams_deps.get_stream_user_service] = lambda: mock_service
+
+            try:
+                res = await client.get("/api/v1/streams/sessions/1/status")
+                assert res.status_code == 200
+                assert res.json() == "LIVE"
+            finally:
+                app.dependency_overrides.clear()

--- a/tests/streams/client/test_router.py
+++ b/tests/streams/client/test_router.py
@@ -1,10 +1,11 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from app.api import deps
 from app.domains.streams import deps as streams_deps
+from app.domains.streams.client.schemas import ArtistItem, SessionDetailResponse
 from app.main import app
 
 
@@ -80,3 +81,62 @@ class TestStreamRouter:
     async def test_list_sessions_validation_error(self, client):
         res = await client.get("/api/v1/streams/sessions", params={"limit": 0})
         assert res.status_code == 422
+
+    async def test_get_session_detail_router(self, client, mock_user):
+        """상세 조회 검증"""
+        app.dependency_overrides[deps.get_current_user] = lambda: mock_user
+
+        mock_session = MagicMock()
+        mock_session.id = 100
+        mock_session.session_name = "Session Detail"
+        mock_session.status = "LIVE"
+        mock_session.start_at = datetime.now()
+        mock_session.end_at = datetime.now() + timedelta(hours=2)
+        mock_session.concert.title = "Concert Detail"
+        mock_session.concert.thumbnail_url = "https://thumb_detail.png"
+        mock_session.concert.category = "K-POP"
+        mock_session.concert.description = "Concert Desc"
+
+        artist_mock = MagicMock()
+        artist_mock.id = 10
+        artist_mock.stage_name = "ArtistX"
+        artist_mock.group_type = "SOLO"
+        artist_mock.profile_img_url = "https://artistx.png"
+        artist_mock.agency = "AgencyX"
+        mapping_mock = MagicMock()
+        mapping_mock.artist = artist_mock
+        mapping_mock.is_main = False
+        mock_session.artist_mappings = [mapping_mock]
+
+        mock_service = AsyncMock()
+        mock_service.get_sessions_detail.return_value = SessionDetailResponse(
+            id=mock_session.id,
+            concert_title=mock_session.concert.title,
+            session_name=mock_session.session_name,
+            thumbnail_url=mock_session.concert.thumbnail_url,
+            category=mock_session.concert.category,
+            status=mock_session.status,
+            description=mock_session.concert.description,
+            lineup=[
+                ArtistItem(
+                    id=mapping_mock.artist.id,
+                    name=mapping_mock.artist.stage_name,
+                    type=mapping_mock.artist.group_type,
+                    profile_img_url=mapping_mock.artist.profile_img_url,
+                    agency=mapping_mock.artist.agency,
+                    is_main=mapping_mock.is_main,
+                )
+            ],
+            start_at=mock_session.start_at,
+            end_at=mock_session.end_at,
+        )
+        app.dependency_overrides[streams_deps.get_stream_user_service] = lambda: mock_service
+
+        try:
+            res = await client.get("/api/v1/streams/sessions/100")
+            assert res.status_code == 200
+            data = res.json()
+            assert data["concert_title"] == "Concert Detail"
+            assert data["lineup"][0]["name"] == "ArtistX"
+        finally:
+            app.dependency_overrides.clear()

--- a/tests/streams/client/test_service.py
+++ b/tests/streams/client/test_service.py
@@ -2,6 +2,7 @@ from datetime import date, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from fastapi import HTTPException
 
 from app.domains.streams.client.service import StreamUserService
 from app.domains.streams.models import (
@@ -105,3 +106,82 @@ class TestStreamService:
 
         today = date.today()
         assert len((await service.list_sessions(from_date=today, to_date=today))[0]) == 1
+
+    async def test_get_sessions_detail_service(self, service):
+        """Service.get_sessions_detail 검증"""
+        concert = await Concert.create(title="Detail Service", category=CategoryType.KPOP)
+        session = await ConcertSession.create(
+            concert=concert,
+            session_name="S Detail",
+            status=StreamStatus.LIVE,
+            start_at=datetime.now(),
+            end_at=datetime.now() + timedelta(hours=1),
+        )
+
+        # 아티스트 생성
+        from app.domains.artists.models import Artist
+        from app.domains.streams.models import ConcertArtist
+
+        artist = await Artist.create(
+            stage_name="ArtistService",
+            group_type="SOLO",
+            profile_img_url="https://a.png",
+            agency="AgencyS",
+        )
+        await ConcertArtist.create(session=session, artist=artist, is_main=True)
+
+        user = MagicMock(id=1)
+        with patch(
+            "app.domains.streams.permissions.StreamPermission.verify_playback_access",
+            new_callable=AsyncMock,
+        ):
+            res = await service.get_sessions_detail(user, session.id)
+            assert res.concert_title == "Detail Service"
+            assert len(res.lineup) == 1
+            assert res.lineup[0].name == "ArtistService"
+
+    async def test_get_viewing_credentials_not_found(self, service):
+        """세션 없음 -> 404"""
+        user = MagicMock(id=1)
+        with pytest.raises(HTTPException) as exc:
+            await service.get_viewing_credentials(9999, user)
+        assert exc.value.status_code == 404
+
+    async def test_refresh_viewing_session_invalid_token(self, service, mock_pb):
+        """잘못된 refresh_token -> 401"""
+        concert = await Concert.create(title="Refresh Invalid")
+        session = await ConcertSession.create(
+            concert=concert,
+            session_name="S1",
+            status=StreamStatus.LIVE,
+            start_at=datetime.now(),
+            end_at=datetime.now() + timedelta(hours=1),
+        )
+        await StreamChannel.create(
+            id=session.id,
+            session=session,
+            playback_url="https://test.com",
+            channel_arn="arn:ivs:test2",
+            ingest_endpoint="https://ingest2.com",
+            stream_key_encrypted="key",
+            is_private=True,
+        )
+
+        user = MagicMock(id=1)
+        # rotate_tokens에서 Exception 발생시키기
+        mock_pb.rotate_tokens.side_effect = Exception("Invalid")
+        service.playback_provider = mock_pb
+
+        with patch(
+            "app.domains.streams.permissions.StreamPermission.verify_playback_access",
+            new_callable=AsyncMock,
+        ):
+            with pytest.raises(HTTPException) as exc:
+                await service.refresh_viewing_session(session.id, user, "bad_rt")
+            assert exc.value.status_code == 401
+
+    async def test_get_sessions_detail_not_found(self, service):
+        user = MagicMock(id=1)
+        with pytest.raises(HTTPException) as exc:
+            await service.get_sessions_detail(user, 99999)  # 존재하지 않는 세션
+        assert exc.value.status_code == 404

--- a/tests/streams/client/test_service.py
+++ b/tests/streams/client/test_service.py
@@ -185,3 +185,10 @@ class TestStreamService:
         with pytest.raises(HTTPException) as exc:
             await service.get_sessions_detail(user, 99999)  # 존재하지 않는 세션
         assert exc.value.status_code == 404
+
+    async def test_get_status_not_found(self, service):
+        """없는 콘서트 세션 조회"""
+        with pytest.raises(HTTPException) as exc_info:
+            await service.get_status(99999)
+        assert exc_info.value.status_code == 404
+        assert "콘서트 세션 정보를 찾을 수 없습니다." in str(exc_info.value.detail)


### PR DESCRIPTION
## ✅ PR 한줄 요약
- 스트리밍 상세 조회 + 상태 조회

## 🔗 관련 이슈
- Jira: NEAR-91

## 🛠️ 변경 내용
- [x] 스트리밍 상세 조회 엔드포인트 구현
- [x] try-except 추가
- [x] 스트리밍 상태 조회 구현

## 🧪 테스트
- [x] 로컬 테스트 완료 (`uv run pytest -q`)
- [x] ruff/mypy 통과 확인
  - [x] `uv run ruff check .`
  - [x] `uv run ruff format --check .`
  - [x] `uv run mypy .`
