### PR TITLE
Near 67 session noti scheduler core

### DIFF
--- a/app/domains/notifications/manager.py
+++ b/app/domains/notifications/manager.py
@@ -18,7 +18,6 @@ class NotificationConnectionManager:
         self._max_per_user = max_per_user
         self._subscriber_task: asyncio.Task[None] | None = None
 
-
     async def connect(self, user_id: str, ws: WebSocket) -> None:
         await ws.accept()
         async with self._lock:
@@ -49,7 +48,6 @@ class NotificationConnectionManager:
         if self._subscriber_task and not self._subscriber_task.done():
             return
         self._subscriber_task = asyncio.create_task(self._subscriber_loop())
-
 
     def _total_connections_locked(self) -> int:
         return sum(len(conns) for conns in self._users.values())
@@ -82,7 +80,6 @@ class NotificationConnectionManager:
             room.discard(ws)
         if not room:
             self._users.pop(user_id, None)
-
 
     async def _send_to_targets(
         self, targets: list[WebSocket], payload: dict[str, Any]

--- a/app/domains/notifications/manager.py
+++ b/app/domains/notifications/manager.py
@@ -1,0 +1,149 @@
+import asyncio
+import contextlib
+import json
+from typing import Any
+
+from fastapi import WebSocket
+
+from app.core.redis import redis_client
+
+NOTIFICATION_CHANNEL = "notifications"
+
+
+class NotificationConnectionManager:
+    def __init__(self, *, max_total: int = 10_000, max_per_user: int = 5) -> None:
+        self._users: dict[str, set[WebSocket]] = {}
+        self._lock = asyncio.Lock()
+        self._max_total = max_total
+        self._max_per_user = max_per_user
+        self._subscriber_task: asyncio.Task[None] | None = None
+
+
+    async def connect(self, user_id: str, ws: WebSocket) -> None:
+        await ws.accept()
+        async with self._lock:
+            self._ensure_capacity_locked(user_id)
+            self._add_ws_locked(user_id, ws)
+
+    async def disconnect(self, user_id: str, ws: WebSocket) -> None:
+        async with self._lock:
+            self._remove_ws_locked(user_id, ws)
+
+    async def send_json(self, user_id: str, payload: dict[str, Any]) -> int:
+        async with self._lock:
+            targets = list(self._users.get(user_id, set()))
+
+        delivered, dead = await self._send_to_targets(targets, payload)
+
+        if dead:
+            async with self._lock:
+                self._prune_dead_locked(user_id, dead)
+
+        return delivered
+
+    async def publish(self, user_id: str, payload: dict[str, Any]) -> None:
+        message = json.dumps({"user_id": user_id, "payload": payload})
+        await redis_client.publish(NOTIFICATION_CHANNEL, message)
+
+    async def ensure_subscriber(self) -> None:
+        if self._subscriber_task and not self._subscriber_task.done():
+            return
+        self._subscriber_task = asyncio.create_task(self._subscriber_loop())
+
+
+    def _total_connections_locked(self) -> int:
+        return sum(len(conns) for conns in self._users.values())
+
+    def _ensure_capacity_locked(self, user_id: str) -> None:
+        if self._total_connections_locked() >= self._max_total:
+            raise RuntimeError("server is busy")
+
+        room = self._users.get(user_id)
+        if room and len(room) >= self._max_per_user:
+            raise RuntimeError("too many connections")
+
+    def _add_ws_locked(self, user_id: str, ws: WebSocket) -> None:
+        room = self._users.setdefault(user_id, set())
+        room.add(ws)
+
+    def _remove_ws_locked(self, user_id: str, ws: WebSocket) -> None:
+        room = self._users.get(user_id)
+        if not room:
+            return
+        room.discard(ws)
+        if not room:
+            self._users.pop(user_id, None)
+
+    def _prune_dead_locked(self, user_id: str, dead: list[WebSocket]) -> None:
+        room = self._users.get(user_id)
+        if not room:
+            return
+        for ws in dead:
+            room.discard(ws)
+        if not room:
+            self._users.pop(user_id, None)
+
+
+    async def _send_to_targets(
+        self, targets: list[WebSocket], payload: dict[str, Any]
+    ) -> tuple[int, list[WebSocket]]:
+        delivered = 0
+        dead: list[WebSocket] = []
+        for ws in targets:
+            try:
+                await ws.send_json(payload)
+                delivered += 1
+            except Exception:
+                dead.append(ws)
+        return delivered, dead
+
+    def _decode_pubsub_data(self, data: Any) -> str | None:
+        if isinstance(data, bytes):
+            try:
+                return data.decode("utf-8")
+            except Exception:
+                return None
+        if isinstance(data, str):
+            return data
+        return None
+
+    def _parse_pubsub_message(self, raw: dict[str, Any]) -> tuple[str, dict[str, Any]] | None:
+        if raw.get("type") != "message":
+            return None
+
+        data_str = self._decode_pubsub_data(raw.get("data"))
+        if not data_str:
+            return None
+
+        try:
+            msg = json.loads(data_str)
+        except json.JSONDecodeError:
+            return None
+
+        user_id = msg.get("user_id")
+        payload = msg.get("payload")
+
+        if not user_id or not isinstance(payload, dict):
+            return None
+
+        return str(user_id), payload
+
+    async def _subscriber_loop(self) -> None:
+        pubsub = redis_client.pubsub()
+        await pubsub.subscribe(NOTIFICATION_CHANNEL)
+
+        try:
+            async for raw in pubsub.listen():
+                parsed = self._parse_pubsub_message(raw)
+                if not parsed:
+                    continue
+                user_id, payload = parsed
+                await self.send_json(user_id, payload)
+        except asyncio.CancelledError:
+            pass
+        finally:
+            with contextlib.suppress(Exception):
+                await pubsub.close()
+
+
+notification_manager = NotificationConnectionManager()

--- a/app/domains/notifications/models.py
+++ b/app/domains/notifications/models.py
@@ -48,6 +48,10 @@ class ConcertNoti(models.Model):
         "models.ConcertSession", related_name="scheduled_notis"
     )
 
+    if TYPE_CHECKING:
+        user_id: int
+        session_id: int
+
     kind = fields.CharEnumField(NotiKind, index=True)
 
     title = fields.CharField(max_length=100)

--- a/app/domains/notifications/models.py
+++ b/app/domains/notifications/models.py
@@ -9,6 +9,7 @@ if TYPE_CHECKING:
 
 
 class NotiKind(str, Enum):
+    DAY_BEFORE = "DAY_BEFORE"
     HOUR_1 = "HOUR_1"
     MIN_30 = "MIN_30"
     START = "START"

--- a/app/domains/notifications/router.py
+++ b/app/domains/notifications/router.py
@@ -1,18 +1,60 @@
-"""notifications 도메인 HTTP 라우터.
+from fastapi import APIRouter, Depends, Query, WebSocket, status
 
-여기에 넣을 것:
-- APIRouter(prefix='...', tags=[...])
-- endpoints 정의(GET/POST/PATCH/DELETE)
-- Depends로 인증/권한 체크
-- service 함수를 호출해서 결과 반환
-
-예:
-- GET /notifications
-- POST /notifications
-"""
-
-from fastapi import APIRouter
+from app.api.deps import get_current_user, get_current_user_from_refresh_cookie_ws
+from app.domains.notifications.models import NotiStatus
+from app.domains.notifications.schemas import (
+    NotificationListResponse,
+    NotificationSettingsResponse,
+    NotificationSettingsUpdate,
+)
+from app.domains.notifications.service import notification_service
+from app.domains.users.models import User
 
 router = APIRouter(prefix="/notifications", tags=["notifications"])
 
-# TODO: endpoints 추가
+
+@router.get("", response_model=NotificationListResponse, status_code=status.HTTP_200_OK)
+async def list_notifications(
+    current_user: User = Depends(get_current_user),
+    status_filter: NotiStatus | None = Query(default=None, alias="status"),
+    limit: int = Query(default=50, ge=1, le=200),
+    offset: int = Query(default=0, ge=0),
+) -> NotificationListResponse:
+    items, total = await notification_service.list_user_notifications(
+        current_user.id,
+        status=status_filter,
+        limit=limit,
+        offset=offset,
+    )
+    return NotificationListResponse(total=total, items=items)
+
+
+@router.get(
+    "/settings",
+    response_model=NotificationSettingsResponse,
+    status_code=status.HTTP_200_OK,
+)
+async def get_settings(
+    current_user: User = Depends(get_current_user),
+) -> NotificationSettingsResponse:
+    return await notification_service.get_user_settings(current_user.id)
+
+
+@router.patch(
+    "/settings",
+    response_model=NotificationSettingsResponse,
+    status_code=status.HTTP_200_OK,
+)
+async def update_settings(
+    data: NotificationSettingsUpdate,
+    current_user: User = Depends(get_current_user),
+) -> NotificationSettingsResponse:
+    return await notification_service.update_user_settings(current_user.id, data)
+
+
+@router.websocket("/ws")
+async def notifications_ws(
+    ws: WebSocket,
+    user: User = Depends(get_current_user_from_refresh_cookie_ws),
+) -> None:
+    await notification_service.handle_ws_connection(ws, user_id=user.id)

--- a/app/domains/notifications/router.py
+++ b/app/domains/notifications/router.py
@@ -7,7 +7,6 @@ from app.domains.users.models import User
 router = APIRouter(prefix="/notifications", tags=["notifications"])
 
 
-
 @router.websocket("/ws")
 async def notifications_ws(
     ws: WebSocket,

--- a/app/domains/notifications/router.py
+++ b/app/domains/notifications/router.py
@@ -1,55 +1,11 @@
-from fastapi import APIRouter, Depends, Query, WebSocket, status
+from fastapi import APIRouter, Depends, WebSocket
 
-from app.api.deps import get_current_user, get_current_user_from_refresh_cookie_ws
-from app.domains.notifications.models import NotiStatus
-from app.domains.notifications.schemas import (
-    NotificationListResponse,
-    NotificationSettingsResponse,
-    NotificationSettingsUpdate,
-)
+from app.api.deps import get_current_user_from_refresh_cookie_ws
 from app.domains.notifications.service import notification_service
 from app.domains.users.models import User
 
 router = APIRouter(prefix="/notifications", tags=["notifications"])
 
-
-@router.get("", response_model=NotificationListResponse, status_code=status.HTTP_200_OK)
-async def list_notifications(
-    current_user: User = Depends(get_current_user),
-    status_filter: NotiStatus | None = Query(default=None, alias="status"),
-    limit: int = Query(default=50, ge=1, le=200),
-    offset: int = Query(default=0, ge=0),
-) -> NotificationListResponse:
-    items, total = await notification_service.list_user_notifications(
-        current_user.id,
-        status=status_filter,
-        limit=limit,
-        offset=offset,
-    )
-    return NotificationListResponse(total=total, items=items)
-
-
-@router.get(
-    "/settings",
-    response_model=NotificationSettingsResponse,
-    status_code=status.HTTP_200_OK,
-)
-async def get_settings(
-    current_user: User = Depends(get_current_user),
-) -> NotificationSettingsResponse:
-    return await notification_service.get_user_settings(current_user.id)
-
-
-@router.patch(
-    "/settings",
-    response_model=NotificationSettingsResponse,
-    status_code=status.HTTP_200_OK,
-)
-async def update_settings(
-    data: NotificationSettingsUpdate,
-    current_user: User = Depends(get_current_user),
-) -> NotificationSettingsResponse:
-    return await notification_service.update_user_settings(current_user.id, data)
 
 
 @router.websocket("/ws")

--- a/app/domains/notifications/schemas.py
+++ b/app/domains/notifications/schemas.py
@@ -5,22 +5,6 @@ from pydantic import BaseModel, ConfigDict
 
 from app.domains.notifications.models import NotiKind, NotiStatus
 
-
-class NotificationSettingsUpdate(BaseModel):
-    artist_noti: bool | None = None
-    live_noti: bool | None = None
-    marketing_noti: bool | None = None
-
-
-class NotificationSettingsResponse(BaseModel):
-    model_config = ConfigDict(from_attributes=True)
-
-    artist_noti: bool
-    live_noti: bool
-    marketing_noti: bool
-    updated_at: datetime
-
-
 class NotificationItem(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
@@ -34,11 +18,6 @@ class NotificationItem(BaseModel):
     sent_at: datetime | None
     created_at: datetime
     updated_at: datetime
-
-
-class NotificationListResponse(BaseModel):
-    total: int
-    items: list[NotificationItem]
 
 
 class NotificationEvent(BaseModel):

--- a/app/domains/notifications/schemas.py
+++ b/app/domains/notifications/schemas.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel, ConfigDict
 
 from app.domains.notifications.models import NotiKind, NotiStatus
 
+
 class NotificationItem(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 

--- a/app/domains/notifications/schemas.py
+++ b/app/domains/notifications/schemas.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import Literal
 
 from pydantic import BaseModel, ConfigDict
 
@@ -38,3 +39,8 @@ class NotificationItem(BaseModel):
 class NotificationListResponse(BaseModel):
     total: int
     items: list[NotificationItem]
+
+
+class NotificationEvent(BaseModel):
+    type: Literal["notification"] = "notification"
+    notification: NotificationItem

--- a/app/domains/notifications/schemas.py
+++ b/app/domains/notifications/schemas.py
@@ -1,9 +1,40 @@
-"""notifications 도메인 Pydantic 스키마.
+from datetime import datetime
 
-여기에 넣을 것:
-- Request/Response 모델들
-- 예: CreateRequest, UpdateRequest, ListResponse, DetailResponse
+from pydantic import BaseModel, ConfigDict
 
-팁:
-- 외부로 노출되는 응답 스키마는 항상 schemas에 모으는게 추적하기 쉬움.
-"""
+from app.domains.notifications.models import NotiKind, NotiStatus
+
+
+class NotificationSettingsUpdate(BaseModel):
+    artist_noti: bool | None = None
+    live_noti: bool | None = None
+    marketing_noti: bool | None = None
+
+
+class NotificationSettingsResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    artist_noti: bool
+    live_noti: bool
+    marketing_noti: bool
+    updated_at: datetime
+
+
+class NotificationItem(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    session_id: int
+    kind: NotiKind
+    title: str
+    message: str
+    send_at: datetime
+    status: NotiStatus
+    sent_at: datetime | None
+    created_at: datetime
+    updated_at: datetime
+
+
+class NotificationListResponse(BaseModel):
+    total: int
+    items: list[NotificationItem]

--- a/app/domains/notifications/service.py
+++ b/app/domains/notifications/service.py
@@ -30,10 +30,11 @@ def _build_schedule(start_at: datetime) -> dict[NotiKind, datetime]:
 
 def _build_content(session: ConcertSession, kind: NotiKind) -> tuple[str, str]:
     start_at = session.start_at
-    if start_at.tzinfo is None:
-        start_at = start_at.replace(tzinfo=KST)
-    else:
-        start_at = start_at.astimezone(KST)
+    start_at = (
+        start_at.replace(tzinfo=KST)
+        if start_at.tzinfo is None
+        else start_at.astimezone(KST)
+    )
     start_str = start_at.strftime("%Y-%m-%d %H:%M")
 
     if kind == NotiKind.HOUR_1:
@@ -151,10 +152,14 @@ class NotificationService:
         now = now_kst()
         until = now + timedelta(hours=hours_ahead)
 
-        sessions = await ConcertSession.filter(
-            start_at__gte=now,
-            start_at__lte=until,
-        ).exclude(status=StreamStatus.ENDED).prefetch_related("concert", "lineup")
+        sessions = (
+            await ConcertSession.filter(
+                start_at__gte=now,
+                start_at__lte=until,
+            )
+            .exclude(status=StreamStatus.ENDED)
+            .prefetch_related("concert", "lineup")
+        )
 
         total = 0
         for session in sessions:
@@ -163,9 +168,9 @@ class NotificationService:
 
     async def deliver_concert_notification(self, noti: ConcertNoti) -> bool:
         """알림을 발행하고 연결된 WS로 전달."""
-        payload = NotificationEvent(
-            notification=NotificationItem.model_validate(noti)
-        ).model_dump(mode="json")
+        payload = NotificationEvent(notification=NotificationItem.model_validate(noti)).model_dump(
+            mode="json"
+        )
         await notification_manager.publish(str(noti.user_id), payload)
         return True
 
@@ -192,9 +197,7 @@ class NotificationService:
         filters: list[Q] = []
 
         if artist_ids:
-            filters.append(
-                Q(noti_setting__artist_noti=True, followed_artists__id__in=artist_ids)
-            )
+            filters.append(Q(noti_setting__artist_noti=True, followed_artists__id__in=artist_ids))
 
         filters.append(Q(fav_categories__category=session.concert.category))
 

--- a/app/domains/notifications/service.py
+++ b/app/domains/notifications/service.py
@@ -1,10 +1,210 @@
-"""notifications 도메인 서비스(비즈니스 로직).
+from __future__ import annotations
 
-여기에 넣을 것:
-- router에서 호출할 함수들
-  - create_*, update_*, delete_*, list_*, get_*
-- DB 접근(Tortoise 쿼리) + 검증/권한체크 + 외부연동 호출(integrations)
+import logging
+from datetime import datetime, timedelta
 
-규칙:
-- router.py에는 로직을 최소화하고, 실제 처리는 service로 내려보내기.
-"""
+from tortoise.exceptions import IntegrityError
+from tortoise.expressions import Q
+
+from app.core.config import KST, now_kst
+from app.domains.notifications.models import ConcertNoti, NotiKind, NotiStatus, UserNoti
+from app.domains.notifications.schemas import NotificationSettingsUpdate
+from app.domains.streams.models import ConcertSession, StreamStatus
+from app.domains.users.models import User
+
+logger = logging.getLogger("app.notifications")
+
+_SCHEDULE_OFFSETS = {
+    NotiKind.HOUR_1: timedelta(hours=1),
+    NotiKind.MIN_30: timedelta(minutes=30),
+    NotiKind.START: timedelta(),
+}
+
+
+def _build_schedule(start_at: datetime) -> dict[NotiKind, datetime]:
+    # 시작시간에 따른 발송시간 계산
+    return {kind: start_at - offset for kind, offset in _SCHEDULE_OFFSETS.items()}
+
+
+def _build_content(session: ConcertSession, kind: NotiKind) -> tuple[str, str]:
+    # 세션과 라이브 시작까지 남은 시간에 따른 알림 내용 생성
+    start_at = session.start_at
+    if start_at.tzinfo is None:
+        start_at = start_at.replace(tzinfo=KST)
+    else:
+        start_at = start_at.astimezone(KST)
+    start_str = start_at.strftime("%Y-%m-%d %H:%M")
+
+    if kind == NotiKind.HOUR_1:
+        prefix = "라이브 시작 1시간 전"
+    elif kind == NotiKind.MIN_30:
+        prefix = "라이브 시작 30분 전"
+    else:
+        prefix = "라이브 시작"
+
+    title = f"{session.concert.title} 라이브 알림"
+    message = f"{prefix}: {session.session_name} ({start_str})"
+    return title, message
+
+
+class NotificationService:
+    async def get_user_settings(self, user_id: int) -> UserNoti:
+        # 유저 알림 설정 정보 조회 및 생성
+        noti = await UserNoti.get_or_none(user_id=user_id)
+        if noti:
+            return noti
+        return await UserNoti.create(user_id=user_id)
+
+    async def update_user_settings(
+        self, user_id: int, data: NotificationSettingsUpdate
+    ) -> UserNoti:
+        # 유저 정보 수정(없으면 생성 후 수정)
+        #! 왜 메모리에 노티도 동일하게 반영함?
+        noti = await self.get_user_settings(user_id)
+        payload = data.model_dump(exclude_unset=True)
+        if payload:
+            now = now_kst()
+            await UserNoti.filter(user_id=user_id).update(**payload, updated_at=now)
+            for key, value in payload.items():
+                setattr(noti, key, value)
+            noti.updated_at = now
+        return noti
+
+    async def list_user_notifications(
+        self,
+        user_id: int,
+        *,
+        status: NotiStatus | None,
+        limit: int,
+        offset: int,
+    ) -> tuple[list[ConcertNoti], int]:
+        # 유저 알림 목록 조회
+        #! 이미 읽은 목록은 조회에서 제외해야함.(컬럼을 따로 만들어야하나?)
+        query = ConcertNoti.filter(user_id=user_id)
+        if status:
+            query = query.filter(status=status)
+        total = await query.count()
+        items = await query.order_by("-send_at").offset(offset).limit(limit)
+        return list(items), total
+
+    async def schedule_session_notifications(
+        self, session_id: int, *, session: ConcertSession | None = None
+    ) -> int:
+        """세션 알림 스케줄 생성하고 알림 수 반환함."""
+        if session is None:
+            session = await ConcertSession.get(id=session_id)
+        await session.fetch_related("concert", "lineup")
+
+        if session.status == StreamStatus.ENDED:
+            return 0
+
+        user_ids = await self._resolve_target_user_ids(session)
+        if not user_ids:
+            return 0
+
+        schedule_map = _build_schedule(session.start_at)
+        total_created = 0
+
+        # 해당 세션에서 kind를 받은 놈은 주면 안 됨
+        for kind, send_at in schedule_map.items():
+            existing_ids = await ConcertNoti.filter(
+                session_id=session.id, kind=kind, user_id__in=user_ids
+            ).values_list("user_id", flat=True)
+            missing_ids = sorted(set(user_ids) - set(existing_ids))
+            if not missing_ids:
+                continue
+
+            # 알림 객체 리스트 만들어서 한번에 집어넣음
+            title, message = _build_content(session, kind)
+            notis = [
+                ConcertNoti(
+                    user_id=user_id,
+                    session_id=session.id,
+                    kind=kind,
+                    title=title,
+                    message=message,
+                    send_at=send_at,
+                    status=NotiStatus.PENDING,
+                )
+                for user_id in missing_ids
+            ]
+
+            try:
+                await ConcertNoti.bulk_create(notis, batch_size=500)
+                total_created += len(notis)
+            except IntegrityError:
+                created = 0
+                for noti in notis:
+                    _, is_created = await ConcertNoti.get_or_create(
+                        user_id=noti.user_id,
+                        session_id=noti.session_id,
+                        kind=noti.kind,
+                        defaults={
+                            "title": noti.title,
+                            "message": noti.message,
+                            "send_at": noti.send_at,
+                            "status": noti.status,
+                        },
+                    )
+                    if is_created:
+                        created += 1
+                total_created += created
+
+        return total_created
+
+    async def schedule_upcoming_sessions(self, hours_ahead: int = 24) -> int:
+        """지금부터 N(24시간 기본)시간 이내 시작하는 세션들 전부 스케줄 생성해줌"""
+        now = now_kst()
+        until = now + timedelta(hours=hours_ahead)
+
+        sessions = await ConcertSession.filter(
+            start_at__gte=now,
+            start_at__lte=until,
+        ).exclude(status=StreamStatus.ENDED).prefetch_related("concert", "lineup")
+
+        total = 0
+        for session in sessions:
+            total += await self.schedule_session_notifications(session.id, session=session)
+        return total
+
+    async def deliver_concert_notification(self, noti: ConcertNoti) -> bool:
+        """
+        실제로 메시지를 전송 할 함수. 지금은 로그로 찍기만 하고있음...
+        웹소켓으로 할 지 SSE로 할지 결정하고 작성
+        """
+        logger.info(
+            "Delivering notification id=%s user_id=%s session_id=%s kind=%s",
+            noti.id,
+            noti.user_id,
+            noti.session_id,
+            noti.kind,
+        )
+        return True
+
+    async def _resolve_target_user_ids(self, session: ConcertSession) -> list[int]:
+        """해당 세션 알림을 받을 유저들을 찾아서 id 리스트로 주는 함수임"""
+        lineup = await session.lineup.all()
+        artist_ids = [artist.id for artist in lineup]
+        filters: list[Q] = []
+
+        if artist_ids:
+            filters.append(
+                Q(noti_setting__artist_noti=True, followed_artists__id__in=artist_ids)
+            )
+
+        filters.append(Q(fav_categories__category=session.concert.category))
+
+        combined = filters[0]
+        for clause in filters[1:]:
+            combined |= clause
+
+        users = (
+            await User.filter(noti_setting__live_noti=True)
+            .filter(combined)
+            .distinct()
+            .values_list("id", flat=True)
+        )
+        return list(users)
+
+
+notification_service = NotificationService()

--- a/app/domains/notifications/service.py
+++ b/app/domains/notifications/service.py
@@ -8,12 +8,8 @@ from tortoise.expressions import Q
 
 from app.core.config import KST, now_kst
 from app.domains.notifications.manager import notification_manager
-from app.domains.notifications.models import ConcertNoti, NotiKind, NotiStatus, UserNoti
-from app.domains.notifications.schemas import (
-    NotificationEvent,
-    NotificationItem,
-    NotificationSettingsUpdate,
-)
+from app.domains.notifications.models import ConcertNoti, NotiKind, NotiStatus
+from app.domains.notifications.schemas import NotificationEvent, NotificationItem
 from app.domains.streams.models import ConcertSession, StreamStatus
 from app.domains.users.models import User
 
@@ -60,40 +56,6 @@ def _build_content(session: ConcertSession, kind: NotiKind) -> tuple[str, str]:
 
 
 class NotificationService:
-    async def get_user_settings(self, user_id: int) -> UserNoti:
-        noti = await UserNoti.get_or_none(user_id=user_id)
-        if noti:
-            return noti
-        return await UserNoti.create(user_id=user_id)
-
-    async def update_user_settings(
-        self, user_id: int, data: NotificationSettingsUpdate
-    ) -> UserNoti:
-        noti = await self.get_user_settings(user_id)
-        payload = data.model_dump(exclude_unset=True)
-        if payload:
-            now = now_kst()
-            await UserNoti.filter(user_id=user_id).update(**payload, updated_at=now)
-            for key, value in payload.items():
-                setattr(noti, key, value)
-            noti.updated_at = now
-        return noti
-
-    async def list_user_notifications(
-        self,
-        user_id: int,
-        *,
-        status: NotiStatus | None,
-        limit: int,
-        offset: int,
-    ) -> tuple[list[ConcertNoti], int]:
-        query = ConcertNoti.filter(user_id=user_id)
-        if status:
-            query = query.filter(status=status)
-        total = await query.count()
-        items = await query.order_by("-send_at").offset(offset).limit(limit)
-        return list(items), total
-
     async def schedule_session_notifications(
         self, session_id: int, *, session: ConcertSession | None = None
     ) -> int:

--- a/app/domains/notifications/service.py
+++ b/app/domains/notifications/service.py
@@ -24,20 +24,30 @@ _SCHEDULE_OFFSETS = {
 }
 
 
-def _build_schedule(start_at: datetime) -> dict[NotiKind, datetime]:
-    return {kind: start_at - offset for kind, offset in _SCHEDULE_OFFSETS.items()}
-
-
-def _build_content(session: ConcertSession, kind: NotiKind) -> tuple[str, str]:
-    start_at = session.start_at
-    start_at = (
+def _normalize_start_at(start_at: datetime) -> datetime:
+    return (
         start_at.replace(tzinfo=KST)
         if start_at.tzinfo is None
         else start_at.astimezone(KST)
     )
+
+
+def _build_schedule(start_at: datetime) -> dict[NotiKind, datetime]:
+    start_at = _normalize_start_at(start_at)
+    schedule = {kind: start_at - offset for kind, offset in _SCHEDULE_OFFSETS.items()}
+    schedule[NotiKind.DAY_BEFORE] = (start_at - timedelta(days=1)).replace(
+        hour=0, minute=0, second=0, microsecond=0
+    )
+    return schedule
+
+
+def _build_content(session: ConcertSession, kind: NotiKind) -> tuple[str, str]:
+    start_at = _normalize_start_at(session.start_at)
     start_str = start_at.strftime("%Y-%m-%d %H:%M")
 
-    if kind == NotiKind.HOUR_1:
+    if kind == NotiKind.DAY_BEFORE:
+        prefix = "내일 라이브 시작 예정"
+    elif kind == NotiKind.HOUR_1:
         prefix = "라이브 시작 1시간 전"
     elif kind == NotiKind.MIN_30:
         prefix = "라이브 시작 30분 전"

--- a/app/domains/notifications/service.py
+++ b/app/domains/notifications/service.py
@@ -1,18 +1,21 @@
 from __future__ import annotations
 
-import logging
 from datetime import datetime, timedelta
 
+from fastapi import WebSocket, WebSocketDisconnect
 from tortoise.exceptions import IntegrityError
 from tortoise.expressions import Q
 
 from app.core.config import KST, now_kst
+from app.domains.notifications.manager import notification_manager
 from app.domains.notifications.models import ConcertNoti, NotiKind, NotiStatus, UserNoti
-from app.domains.notifications.schemas import NotificationSettingsUpdate
+from app.domains.notifications.schemas import (
+    NotificationEvent,
+    NotificationItem,
+    NotificationSettingsUpdate,
+)
 from app.domains.streams.models import ConcertSession, StreamStatus
 from app.domains.users.models import User
-
-logger = logging.getLogger("app.notifications")
 
 _SCHEDULE_OFFSETS = {
     NotiKind.HOUR_1: timedelta(hours=1),
@@ -22,12 +25,10 @@ _SCHEDULE_OFFSETS = {
 
 
 def _build_schedule(start_at: datetime) -> dict[NotiKind, datetime]:
-    # 시작시간에 따른 발송시간 계산
     return {kind: start_at - offset for kind, offset in _SCHEDULE_OFFSETS.items()}
 
 
 def _build_content(session: ConcertSession, kind: NotiKind) -> tuple[str, str]:
-    # 세션과 라이브 시작까지 남은 시간에 따른 알림 내용 생성
     start_at = session.start_at
     if start_at.tzinfo is None:
         start_at = start_at.replace(tzinfo=KST)
@@ -49,7 +50,6 @@ def _build_content(session: ConcertSession, kind: NotiKind) -> tuple[str, str]:
 
 class NotificationService:
     async def get_user_settings(self, user_id: int) -> UserNoti:
-        # 유저 알림 설정 정보 조회 및 생성
         noti = await UserNoti.get_or_none(user_id=user_id)
         if noti:
             return noti
@@ -58,8 +58,6 @@ class NotificationService:
     async def update_user_settings(
         self, user_id: int, data: NotificationSettingsUpdate
     ) -> UserNoti:
-        # 유저 정보 수정(없으면 생성 후 수정)
-        #! 왜 메모리에 노티도 동일하게 반영함?
         noti = await self.get_user_settings(user_id)
         payload = data.model_dump(exclude_unset=True)
         if payload:
@@ -78,8 +76,6 @@ class NotificationService:
         limit: int,
         offset: int,
     ) -> tuple[list[ConcertNoti], int]:
-        # 유저 알림 목록 조회
-        #! 이미 읽은 목록은 조회에서 제외해야함.(컬럼을 따로 만들어야하나?)
         query = ConcertNoti.filter(user_id=user_id)
         if status:
             query = query.filter(status=status)
@@ -90,7 +86,7 @@ class NotificationService:
     async def schedule_session_notifications(
         self, session_id: int, *, session: ConcertSession | None = None
     ) -> int:
-        """세션 알림 스케줄 생성하고 알림 수 반환함."""
+        """세션 알림 스케줄 생성 후 생성된 알림 수 반환."""
         if session is None:
             session = await ConcertSession.get(id=session_id)
         await session.fetch_related("concert", "lineup")
@@ -105,7 +101,6 @@ class NotificationService:
         schedule_map = _build_schedule(session.start_at)
         total_created = 0
 
-        # 해당 세션에서 kind를 받은 놈은 주면 안 됨
         for kind, send_at in schedule_map.items():
             existing_ids = await ConcertNoti.filter(
                 session_id=session.id, kind=kind, user_id__in=user_ids
@@ -114,7 +109,6 @@ class NotificationService:
             if not missing_ids:
                 continue
 
-            # 알림 객체 리스트 만들어서 한번에 집어넣음
             title, message = _build_content(session, kind)
             notis = [
                 ConcertNoti(
@@ -153,7 +147,7 @@ class NotificationService:
         return total_created
 
     async def schedule_upcoming_sessions(self, hours_ahead: int = 24) -> int:
-        """지금부터 N(24시간 기본)시간 이내 시작하는 세션들 전부 스케줄 생성해줌"""
+        """지금부터 N시간 이내 시작하는 세션들의 알림을 생성."""
         now = now_kst()
         until = now + timedelta(hours=hours_ahead)
 
@@ -168,21 +162,31 @@ class NotificationService:
         return total
 
     async def deliver_concert_notification(self, noti: ConcertNoti) -> bool:
-        """
-        실제로 메시지를 전송 할 함수. 지금은 로그로 찍기만 하고있음...
-        웹소켓으로 할 지 SSE로 할지 결정하고 작성
-        """
-        logger.info(
-            "Delivering notification id=%s user_id=%s session_id=%s kind=%s",
-            noti.id,
-            noti.user_id,
-            noti.session_id,
-            noti.kind,
-        )
+        """알림을 발행하고 연결된 WS로 전달."""
+        payload = NotificationEvent(
+            notification=NotificationItem.model_validate(noti)
+        ).model_dump(mode="json")
+        await notification_manager.publish(str(noti.user_id), payload)
         return True
 
+    async def handle_ws_connection(self, ws: WebSocket, *, user_id: int) -> None:
+        user_key = str(user_id)
+        try:
+            await notification_manager.ensure_subscriber()
+            await notification_manager.connect(user_key, ws)
+        except RuntimeError:
+            await ws.close(code=1008)
+            return
+
+        try:
+            while True:
+                await ws.receive_text()
+        except WebSocketDisconnect:
+            pass
+        finally:
+            await notification_manager.disconnect(user_key, ws)
+
     async def _resolve_target_user_ids(self, session: ConcertSession) -> list[int]:
-        """해당 세션 알림을 받을 유저들을 찾아서 id 리스트로 주는 함수임"""
         lineup = await session.lineup.all()
         artist_ids = [artist.id for artist in lineup]
         filters: list[Q] = []

--- a/app/domains/notifications/service.py
+++ b/app/domains/notifications/service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta
+from typing import cast
 
 from fastapi import WebSocket, WebSocketDisconnect
 from tortoise.exceptions import IntegrityError
@@ -21,11 +22,7 @@ _SCHEDULE_OFFSETS = {
 
 
 def _normalize_start_at(start_at: datetime) -> datetime:
-    return (
-        start_at.replace(tzinfo=KST)
-        if start_at.tzinfo is None
-        else start_at.astimezone(KST)
-    )
+    return start_at.replace(tzinfo=KST) if start_at.tzinfo is None else start_at.astimezone(KST)
 
 
 def _build_schedule(start_at: datetime) -> dict[NotiKind, datetime]:
@@ -75,9 +72,12 @@ class NotificationService:
         total_created = 0
 
         for kind, send_at in schedule_map.items():
-            existing_ids = await ConcertNoti.filter(
-                session_id=session.id, kind=kind, user_id__in=user_ids
-            ).values_list("user_id", flat=True)
+            existing_ids = cast(
+                "list[int]",
+                await ConcertNoti.filter(
+                    session_id=session.id, kind=kind, user_id__in=user_ids
+                ).values_list("user_id", flat=True),
+            )
             missing_ids = sorted(set(user_ids) - set(existing_ids))
             if not missing_ids:
                 continue
@@ -102,9 +102,11 @@ class NotificationService:
             except IntegrityError:
                 created = 0
                 for noti in notis:
+                    user_id = noti.user_id
+                    session_id = noti.session_id
                     _, is_created = await ConcertNoti.get_or_create(
-                        user_id=noti.user_id,
-                        session_id=noti.session_id,
+                        user_id=user_id,
+                        session_id=session_id,
                         kind=noti.kind,
                         defaults={
                             "title": noti.title,
@@ -143,7 +145,8 @@ class NotificationService:
         payload = NotificationEvent(notification=NotificationItem.model_validate(noti)).model_dump(
             mode="json"
         )
-        await notification_manager.publish(str(noti.user_id), payload)
+        user_id = noti.user_id
+        await notification_manager.publish(str(user_id), payload)
         return True
 
     async def handle_ws_connection(self, ws: WebSocket, *, user_id: int) -> None:
@@ -177,11 +180,12 @@ class NotificationService:
         for clause in filters[1:]:
             combined |= clause
 
-        users = (
+        users = cast(
+            "list[int]",
             await User.filter(noti_setting__live_noti=True)
             .filter(combined)
             .distinct()
-            .values_list("id", flat=True)
+            .values_list("id", flat=True),
         )
         return list(users)
 

--- a/app/domains/notifications/tasks.py
+++ b/app/domains/notifications/tasks.py
@@ -42,7 +42,11 @@ async def _dispatch_due_notifications(batch_size: int) -> int:
     now = now_kst()
     total = 0
     due_query = (
-        ConcertNoti.filter(status=NotiStatus.PENDING, send_at__lte=now)
+        ConcertNoti.filter(
+            status=NotiStatus.PENDING,
+            send_at__lte=now,
+            session__status=StreamStatus.READY,
+        )
         .exclude(kind=NotiKind.START)
         .order_by("send_at")
     )

--- a/app/domains/notifications/tasks.py
+++ b/app/domains/notifications/tasks.py
@@ -1,5 +1,8 @@
 import asyncio
 import logging
+from collections.abc import Coroutine
+from datetime import datetime
+from typing import Any
 
 from tortoise import Tortoise
 
@@ -13,7 +16,7 @@ from app.tasks.celery_app import celery_app
 logger = logging.getLogger("app.notifications")
 
 
-async def _run_with_db(coro):
+async def _run_with_db[T](coro: Coroutine[Any, Any, T]) -> T:
     await Tortoise.init(config=TORTOISE_ORM)
     try:
         return await coro
@@ -21,21 +24,27 @@ async def _run_with_db(coro):
         await Tortoise.close_connections()
 
 
-@celery_app.task(name="app.domains.notifications.tasks.schedule_session_notifications")
+@celery_app.task(  # type: ignore[untyped-decorator]
+    name="app.domains.notifications.tasks.schedule_session_notifications"
+)
 def schedule_session_notifications(session_id: int) -> int:
     return asyncio.run(
         _run_with_db(notification_service.schedule_session_notifications(session_id))
     )
 
 
-@celery_app.task(name="app.domains.notifications.tasks.schedule_upcoming_session_notifications")
+@celery_app.task(  # type: ignore[untyped-decorator]
+    name="app.domains.notifications.tasks.schedule_upcoming_session_notifications"
+)
 def schedule_upcoming_session_notifications(hours_ahead: int = 24) -> int:
     return asyncio.run(
         _run_with_db(notification_service.schedule_upcoming_sessions(hours_ahead=hours_ahead))
     )
 
 
-@celery_app.task(name="app.domains.notifications.tasks.dispatch_due_notifications")
+@celery_app.task(  # type: ignore[untyped-decorator]
+    name="app.domains.notifications.tasks.dispatch_due_notifications"
+)
 def dispatch_due_notifications(batch_size: int = 200) -> int:
     return asyncio.run(_run_with_db(_dispatch_due_notifications(batch_size)))
 
@@ -64,7 +73,7 @@ async def _dispatch_due_notifications(batch_size: int) -> int:
     return total
 
 
-async def _dispatch_notifications(query, now, batch_size: int) -> int:
+async def _dispatch_notifications(query: Any, now: datetime, batch_size: int) -> int:
     items = await query.limit(batch_size)
     sent = 0
 

--- a/app/domains/notifications/tasks.py
+++ b/app/domains/notifications/tasks.py
@@ -1,10 +1,72 @@
-"""notifications 관련 Celery task 엔트리포인트.
+import asyncio
+import logging
 
-여기에 넣을 것:
-- send_live_notification(stream_id, ...)
-- 예약 알림(라이브 시작 전 n분)
-- 실패 재시도 정책
+from tortoise import Tortoise
 
-주의:
-- tasks/celery_app.py의 celery 인스턴스를 import해서 사용.
-"""
+from app.core.config import now_kst
+from app.core.tortoise_config import TORTOISE_ORM
+from app.domains.notifications.models import ConcertNoti, NotiStatus
+from app.domains.notifications.service import notification_service
+from app.tasks.celery_app import celery_app
+
+logger = logging.getLogger("app.notifications")
+
+
+async def _run_with_db(coro):
+    await Tortoise.init(config=TORTOISE_ORM)
+    try:
+        return await coro
+    finally:
+        await Tortoise.close_connections()
+
+
+@celery_app.task(name="app.domains.notifications.tasks.schedule_session_notifications")
+def schedule_session_notifications(session_id: int) -> int:
+    return asyncio.run(_run_with_db(notification_service.schedule_session_notifications(session_id)))
+
+
+@celery_app.task(name="app.domains.notifications.tasks.schedule_upcoming_session_notifications")
+def schedule_upcoming_session_notifications(hours_ahead: int = 24) -> int:
+    return asyncio.run(
+        _run_with_db(notification_service.schedule_upcoming_sessions(hours_ahead=hours_ahead))
+    )
+
+
+@celery_app.task(name="app.domains.notifications.tasks.dispatch_due_notifications")
+def dispatch_due_notifications(batch_size: int = 200) -> int:
+    return asyncio.run(_run_with_db(_dispatch_due_notifications(batch_size)))
+
+
+async def _dispatch_due_notifications(batch_size: int) -> int:
+    now = now_kst()
+    due = (
+        await ConcertNoti.filter(status=NotiStatus.PENDING, send_at__lte=now)
+        .order_by("send_at")
+        .limit(batch_size)
+    )
+
+    sent = 0
+    for noti in due:
+        claimed = await ConcertNoti.filter(
+            id=noti.id, status=NotiStatus.PENDING
+        ).update(status=NotiStatus.PROCESSING, updated_at=now)
+        if not claimed:
+            continue
+
+        try:
+            ok = await notification_service.deliver_concert_notification(noti)
+        except Exception:
+            logger.exception("Failed to deliver notification id=%s", noti.id)
+            ok = False
+
+        if ok:
+            await ConcertNoti.filter(id=noti.id).update(
+                status=NotiStatus.SENT, sent_at=now, updated_at=now
+            )
+            sent += 1
+        else:
+            await ConcertNoti.filter(id=noti.id).update(
+                status=NotiStatus.FAILED, updated_at=now
+            )
+
+    return sent

--- a/app/domains/notifications/tasks.py
+++ b/app/domains/notifications/tasks.py
@@ -5,8 +5,9 @@ from tortoise import Tortoise
 
 from app.core.config import now_kst
 from app.core.tortoise_config import TORTOISE_ORM
-from app.domains.notifications.models import ConcertNoti, NotiStatus
+from app.domains.notifications.models import ConcertNoti, NotiKind, NotiStatus
 from app.domains.notifications.service import notification_service
+from app.domains.streams.models import StreamStatus
 from app.tasks.celery_app import celery_app
 
 logger = logging.getLogger("app.notifications")
@@ -39,14 +40,31 @@ def dispatch_due_notifications(batch_size: int = 200) -> int:
 
 async def _dispatch_due_notifications(batch_size: int) -> int:
     now = now_kst()
-    due = (
-        await ConcertNoti.filter(status=NotiStatus.PENDING, send_at__lte=now)
+    total = 0
+    due_query = (
+        ConcertNoti.filter(status=NotiStatus.PENDING, send_at__lte=now)
+        .exclude(kind=NotiKind.START)
         .order_by("send_at")
-        .limit(batch_size)
     )
+    total += await _dispatch_notifications(due_query, now, batch_size)
 
+    start_query = (
+        ConcertNoti.filter(
+            status=NotiStatus.PENDING,
+            kind=NotiKind.START,
+            session__status=StreamStatus.LIVE,
+        )
+        .order_by("send_at")
+    )
+    total += await _dispatch_notifications(start_query, now, batch_size)
+
+    return total
+
+async def _dispatch_notifications(query, now, batch_size: int) -> int:
+    items = await query.limit(batch_size)
     sent = 0
-    for noti in due:
+
+    for noti in items:
         claimed = await ConcertNoti.filter(
             id=noti.id, status=NotiStatus.PENDING
         ).update(status=NotiStatus.PROCESSING, updated_at=now)

--- a/app/domains/notifications/tasks.py
+++ b/app/domains/notifications/tasks.py
@@ -23,7 +23,9 @@ async def _run_with_db(coro):
 
 @celery_app.task(name="app.domains.notifications.tasks.schedule_session_notifications")
 def schedule_session_notifications(session_id: int) -> int:
-    return asyncio.run(_run_with_db(notification_service.schedule_session_notifications(session_id)))
+    return asyncio.run(
+        _run_with_db(notification_service.schedule_session_notifications(session_id))
+    )
 
 
 @celery_app.task(name="app.domains.notifications.tasks.schedule_upcoming_session_notifications")
@@ -52,26 +54,24 @@ async def _dispatch_due_notifications(batch_size: int) -> int:
     )
     total += await _dispatch_notifications(due_query, now, batch_size)
 
-    start_query = (
-        ConcertNoti.filter(
-            status=NotiStatus.PENDING,
-            kind=NotiKind.START,
-            session__status=StreamStatus.LIVE,
-        )
-        .order_by("send_at")
-    )
+    start_query = ConcertNoti.filter(
+        status=NotiStatus.PENDING,
+        kind=NotiKind.START,
+        session__status=StreamStatus.LIVE,
+    ).order_by("send_at")
     total += await _dispatch_notifications(start_query, now, batch_size)
 
     return total
+
 
 async def _dispatch_notifications(query, now, batch_size: int) -> int:
     items = await query.limit(batch_size)
     sent = 0
 
     for noti in items:
-        claimed = await ConcertNoti.filter(
-            id=noti.id, status=NotiStatus.PENDING
-        ).update(status=NotiStatus.PROCESSING, updated_at=now)
+        claimed = await ConcertNoti.filter(id=noti.id, status=NotiStatus.PENDING).update(
+            status=NotiStatus.PROCESSING, updated_at=now
+        )
         if not claimed:
             continue
 
@@ -87,8 +87,6 @@ async def _dispatch_notifications(query, now, batch_size: int) -> int:
             )
             sent += 1
         else:
-            await ConcertNoti.filter(id=noti.id).update(
-                status=NotiStatus.FAILED, updated_at=now
-            )
+            await ConcertNoti.filter(id=noti.id).update(status=NotiStatus.FAILED, updated_at=now)
 
     return sent

--- a/tests/notifications/test_manager.py
+++ b/tests/notifications/test_manager.py
@@ -118,7 +118,9 @@ async def test_manager_ensure_subscriber_creates_task() -> None:
     dummy_task = SimpleNamespace(done=lambda: False)
 
     with (
-        patch("app.domains.notifications.manager.asyncio.create_task", return_value=dummy_task) as create_task,
+        patch(
+            "app.domains.notifications.manager.asyncio.create_task", return_value=dummy_task
+        ) as create_task,
         patch.object(manager, "_subscriber_loop", new=AsyncMock()),
     ):
         await manager.ensure_subscriber()
@@ -145,9 +147,7 @@ async def test_manager_decode_and_parse_pubsub() -> None:
     assert manager._parse_pubsub_message({"type": "message", "data": None}) is None
     assert manager._parse_pubsub_message({"type": "message", "data": "{"}) is None
     assert (
-        manager._parse_pubsub_message(
-            {"type": "message", "data": '{"user_id": "", "payload": {}}'}
-        )
+        manager._parse_pubsub_message({"type": "message", "data": '{"user_id": "", "payload": {}}'})
         is None
     )
     assert (

--- a/tests/notifications/test_manager.py
+++ b/tests/notifications/test_manager.py
@@ -1,0 +1,196 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.domains.notifications.manager import (
+    NOTIFICATION_CHANNEL,
+    NotificationConnectionManager,
+)
+
+
+class DummyWebSocket:
+    def __init__(self, *, fail_send: bool = False) -> None:
+        self.accepted = False
+        self.sent: list[dict[str, object]] = []
+        self._fail_send = fail_send
+
+    async def accept(self) -> None:
+        self.accepted = True
+
+    async def send_json(self, payload: dict[str, object]) -> None:
+        if self._fail_send:
+            raise RuntimeError("send failed")
+        self.sent.append(payload)
+
+
+class FakePubSub:
+    def __init__(self, messages: list[dict[str, object]], *, raise_cancel: bool = False) -> None:
+        self._messages = messages
+        self._raise_cancel = raise_cancel
+        self.subscribed: str | None = None
+        self.closed = False
+
+    async def subscribe(self, channel: str) -> None:
+        self.subscribed = channel
+
+    async def close(self) -> None:
+        self.closed = True
+
+    async def listen(self):
+        if self._raise_cancel:
+            raise asyncio.CancelledError()
+        for message in self._messages:
+            yield message
+
+
+class FakeRedis:
+    def __init__(self, pubsub: FakePubSub) -> None:
+        self._pubsub = pubsub
+
+    def pubsub(self) -> FakePubSub:
+        return self._pubsub
+
+
+@pytest.mark.asyncio
+async def test_manager_connect_disconnect_and_capacity() -> None:
+    manager = NotificationConnectionManager(max_total=1, max_per_user=1)
+    ws1 = DummyWebSocket()
+    await manager.connect("u1", ws1)
+    assert ws1.accepted is True
+    assert manager._users["u1"] == {ws1}
+
+    ws2 = DummyWebSocket()
+    with pytest.raises(RuntimeError, match="server is busy"):
+        await manager.connect("u2", ws2)
+
+    manager = NotificationConnectionManager(max_total=10, max_per_user=1)
+    ws3 = DummyWebSocket()
+    ws4 = DummyWebSocket()
+    await manager.connect("u1", ws3)
+    with pytest.raises(RuntimeError, match="too many connections"):
+        await manager.connect("u1", ws4)
+
+    await manager.disconnect("u1", ws3)
+    assert "u1" not in manager._users
+
+    await manager.disconnect("missing", ws3)
+
+
+@pytest.mark.asyncio
+async def test_manager_send_json_prunes_dead_and_removes_empty() -> None:
+    manager = NotificationConnectionManager()
+    good = DummyWebSocket()
+    bad = DummyWebSocket(fail_send=True)
+    await manager.connect("u1", good)
+    await manager.connect("u1", bad)
+
+    delivered = await manager.send_json("u1", {"ok": True})
+    assert delivered == 1
+    assert manager._users["u1"] == {good}
+
+    manager._prune_dead_locked("missing", [bad])
+
+    manager2 = NotificationConnectionManager()
+    only_bad = DummyWebSocket(fail_send=True)
+    await manager2.connect("u2", only_bad)
+    delivered = await manager2.send_json("u2", {"ok": True})
+    assert delivered == 0
+    assert "u2" not in manager2._users
+
+
+@pytest.mark.asyncio
+async def test_manager_publish_calls_redis() -> None:
+    manager = NotificationConnectionManager()
+    mock_publish = AsyncMock()
+    fake_redis = SimpleNamespace(publish=mock_publish)
+
+    with patch("app.domains.notifications.manager.redis_client", new=fake_redis):
+        await manager.publish("u1", {"ok": True})
+
+    mock_publish.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_manager_ensure_subscriber_creates_task() -> None:
+    manager = NotificationConnectionManager()
+    dummy_task = SimpleNamespace(done=lambda: False)
+
+    with (
+        patch("app.domains.notifications.manager.asyncio.create_task", return_value=dummy_task) as create_task,
+        patch.object(manager, "_subscriber_loop", new=AsyncMock()),
+    ):
+        await manager.ensure_subscriber()
+
+    assert manager._subscriber_task is dummy_task
+    create_task.assert_called_once()
+
+    manager._subscriber_task = SimpleNamespace(done=lambda: False)
+    with patch("app.domains.notifications.manager.asyncio.create_task") as create_task:
+        await manager.ensure_subscriber()
+    create_task.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_manager_decode_and_parse_pubsub() -> None:
+    manager = NotificationConnectionManager()
+
+    assert manager._decode_pubsub_data(b"ok") == "ok"
+    assert manager._decode_pubsub_data("text") == "text"
+    assert manager._decode_pubsub_data(123) is None
+    assert manager._decode_pubsub_data(b"\xff") is None
+
+    assert manager._parse_pubsub_message({"type": "subscribe"}) is None
+    assert manager._parse_pubsub_message({"type": "message", "data": None}) is None
+    assert manager._parse_pubsub_message({"type": "message", "data": "{"}) is None
+    assert (
+        manager._parse_pubsub_message(
+            {"type": "message", "data": '{"user_id": "", "payload": {}}'}
+        )
+        is None
+    )
+    assert (
+        manager._parse_pubsub_message(
+            {"type": "message", "data": '{"user_id": "1", "payload": "no"}'}
+        )
+        is None
+    )
+    assert manager._parse_pubsub_message(
+        {"type": "message", "data": '{"user_id": "1", "payload": {"a": 1}}'}
+    ) == ("1", {"a": 1})
+
+
+@pytest.mark.asyncio
+async def test_manager_subscriber_loop_processes_messages() -> None:
+    manager = NotificationConnectionManager()
+    pubsub = FakePubSub(
+        [
+            {"type": "subscribe", "data": "ignored"},
+            {"type": "message", "data": '{"user_id": "1", "payload": {"a": 1}}'},
+        ]
+    )
+    fake_redis = FakeRedis(pubsub)
+
+    with (
+        patch("app.domains.notifications.manager.redis_client", new=fake_redis),
+        patch.object(manager, "send_json", new=AsyncMock()) as mock_send,
+    ):
+        await manager._subscriber_loop()
+
+    assert pubsub.subscribed == NOTIFICATION_CHANNEL
+    assert pubsub.closed is True
+    mock_send.assert_awaited_once_with("1", {"a": 1})
+
+
+@pytest.mark.asyncio
+async def test_manager_subscriber_loop_handles_cancel() -> None:
+    manager = NotificationConnectionManager()
+    pubsub = FakePubSub([], raise_cancel=True)
+    fake_redis = FakeRedis(pubsub)
+
+    with patch("app.domains.notifications.manager.redis_client", new=fake_redis):
+        await manager._subscriber_loop()
+
+    assert pubsub.subscribed == NOTIFICATION_CHANNEL
+    assert pubsub.closed is True

--- a/tests/notifications/test_service.py
+++ b/tests/notifications/test_service.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -42,7 +42,7 @@ async def test_normalize_start_at_handles_naive_and_aware() -> None:
     assert normalized.tzinfo == KST
     assert normalized.hour == 10
 
-    aware = datetime(2024, 1, 1, 1, 0, tzinfo=timezone.utc)
+    aware = datetime(2024, 1, 1, 1, 0, tzinfo=UTC)
     normalized = _normalize_start_at(aware)
     assert normalized.tzinfo == KST
     assert normalized.hour == 10
@@ -52,7 +52,9 @@ async def test_normalize_start_at_handles_naive_and_aware() -> None:
 async def test_build_schedule_and_content_variants() -> None:
     concert = await Concert.create(title="Notice", category=CategoryType.KPOP)
     start_at = datetime(2024, 1, 2, 8, 0)
-    session = await ConcertSession.create(concert=concert, session_name="Session A", start_at=start_at)
+    session = await ConcertSession.create(
+        concert=concert, session_name="Session A", start_at=start_at
+    )
     await session.fetch_related("concert")
 
     schedule = _build_schedule(start_at)
@@ -136,7 +138,9 @@ async def test_schedule_session_notifications_returns_zero_for_ended() -> None:
 @pytest.mark.asyncio
 async def test_schedule_session_notifications_returns_zero_for_no_targets() -> None:
     concert = await Concert.create(title="NoTarget", category=CategoryType.KPOP)
-    session = await ConcertSession.create(concert=concert, session_name="NoTarget", start_at=now_kst())
+    session = await ConcertSession.create(
+        concert=concert, session_name="NoTarget", start_at=now_kst()
+    )
 
     service = NotificationService()
     with patch.object(service, "_resolve_target_user_ids", new=AsyncMock(return_value=[])):
@@ -164,7 +168,9 @@ async def test_schedule_upcoming_sessions_filters_and_calls() -> None:
     dummy_query = _DummyQuery([ready_session])
     with (
         patch("app.domains.notifications.service.ConcertSession.filter", return_value=dummy_query),
-        patch.object(service, "schedule_session_notifications", new=AsyncMock(return_value=1)) as mock_sched,
+        patch.object(
+            service, "schedule_session_notifications", new=AsyncMock(return_value=1)
+        ) as mock_sched,
     ):
         total = await service.schedule_upcoming_sessions(hours_ahead=2)
 
@@ -183,7 +189,9 @@ async def test_deliver_concert_notification_publishes() -> None:
         nickname="publish_user",
     )
     concert = await Concert.create(title="Deliver", category=CategoryType.KPOP)
-    session = await ConcertSession.create(concert=concert, session_name="Delivery", start_at=now_kst())
+    session = await ConcertSession.create(
+        concert=concert, session_name="Delivery", start_at=now_kst()
+    )
     noti = await ConcertNoti.create(
         user=user,
         session=session,
@@ -195,7 +203,9 @@ async def test_deliver_concert_notification_publishes() -> None:
     )
 
     service = NotificationService()
-    with patch("app.domains.notifications.service.notification_manager.publish", new=AsyncMock()) as mock_pub:
+    with patch(
+        "app.domains.notifications.service.notification_manager.publish", new=AsyncMock()
+    ) as mock_pub:
         ok = await service.deliver_concert_notification(noti)
 
     assert ok is True
@@ -212,9 +222,14 @@ async def test_handle_ws_connection_disconnects() -> None:
     ws.receive_text = AsyncMock(side_effect=WebSocketDisconnect())
 
     with (
-        patch("app.domains.notifications.service.notification_manager.ensure_subscriber", new=AsyncMock()),
+        patch(
+            "app.domains.notifications.service.notification_manager.ensure_subscriber",
+            new=AsyncMock(),
+        ),
         patch("app.domains.notifications.service.notification_manager.connect", new=AsyncMock()),
-        patch("app.domains.notifications.service.notification_manager.disconnect", new=AsyncMock()) as mock_disconnect,
+        patch(
+            "app.domains.notifications.service.notification_manager.disconnect", new=AsyncMock()
+        ) as mock_disconnect,
     ):
         await service.handle_ws_connection(ws, user_id=1)
 
@@ -227,12 +242,17 @@ async def test_handle_ws_connection_runtime_error_closes() -> None:
     ws = AsyncMock()
 
     with (
-        patch("app.domains.notifications.service.notification_manager.ensure_subscriber", new=AsyncMock()),
+        patch(
+            "app.domains.notifications.service.notification_manager.ensure_subscriber",
+            new=AsyncMock(),
+        ),
         patch(
             "app.domains.notifications.service.notification_manager.connect",
             new=AsyncMock(side_effect=RuntimeError("busy")),
         ),
-        patch("app.domains.notifications.service.notification_manager.disconnect", new=AsyncMock()) as mock_disconnect,
+        patch(
+            "app.domains.notifications.service.notification_manager.disconnect", new=AsyncMock()
+        ) as mock_disconnect,
     ):
         await service.handle_ws_connection(ws, user_id=1)
 

--- a/tests/notifications/test_service.py
+++ b/tests/notifications/test_service.py
@@ -1,0 +1,270 @@
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import WebSocketDisconnect
+from tortoise.exceptions import IntegrityError
+
+from app.core.config import KST, now_kst
+from app.domains.artists.models import Artist
+from app.domains.notifications.models import ConcertNoti, NotiKind, NotiStatus, UserNoti
+from app.domains.notifications.service import (
+    NotificationService,
+    _build_content,
+    _build_schedule,
+    _normalize_start_at,
+)
+from app.domains.streams.models import CategoryType, Concert, ConcertSession, StreamStatus
+from app.domains.users.models import ProviderChoice, User, UserCatFav
+
+
+class _DummyQuery:
+    def __init__(self, result):
+        self._result = result
+
+    def exclude(self, **kwargs):
+        return self
+
+    def prefetch_related(self, *args, **kwargs):
+        return self
+
+    def __await__(self):
+        async def _run():
+            return self._result
+
+        return _run().__await__()
+
+
+@pytest.mark.asyncio
+async def test_normalize_start_at_handles_naive_and_aware() -> None:
+    naive = datetime(2024, 1, 1, 10, 0)
+    normalized = _normalize_start_at(naive)
+    assert normalized.tzinfo == KST
+    assert normalized.hour == 10
+
+    aware = datetime(2024, 1, 1, 1, 0, tzinfo=timezone.utc)
+    normalized = _normalize_start_at(aware)
+    assert normalized.tzinfo == KST
+    assert normalized.hour == 10
+
+
+@pytest.mark.asyncio
+async def test_build_schedule_and_content_variants() -> None:
+    concert = await Concert.create(title="Notice", category=CategoryType.KPOP)
+    start_at = datetime(2024, 1, 2, 8, 0)
+    session = await ConcertSession.create(concert=concert, session_name="Session A", start_at=start_at)
+    await session.fetch_related("concert")
+
+    schedule = _build_schedule(start_at)
+    assert schedule[NotiKind.START].hour == 8
+    assert schedule[NotiKind.HOUR_1].hour == 7
+    assert schedule[NotiKind.MIN_30].minute == 30
+    assert schedule[NotiKind.DAY_BEFORE].date().isoformat() == "2024-01-01"
+    assert schedule[NotiKind.DAY_BEFORE].hour == 0
+
+    expected = {
+        NotiKind.DAY_BEFORE: "내일 라이브 시작 예정",
+        NotiKind.HOUR_1: "라이브 시작 1시간 전",
+        NotiKind.MIN_30: "라이브 시작 30분 전",
+        NotiKind.START: "라이브 시작",
+    }
+    for kind, prefix in expected.items():
+        title, message = _build_content(session, kind)
+        assert concert.title in title
+        assert prefix in message
+        assert session.session_name in message
+
+
+@pytest.mark.asyncio
+async def test_schedule_session_notifications_creates_and_skips_duplicates() -> None:
+    user = await User.create(
+        provider=ProviderChoice.KAKAO,
+        provider_id="kakao_notice",
+        nickname="notice_user",
+    )
+    concert = await Concert.create(title="Schedule", category=CategoryType.KPOP)
+    session = await ConcertSession.create(concert=concert, session_name="One", start_at=now_kst())
+
+    service = NotificationService()
+    with patch.object(service, "_resolve_target_user_ids", new=AsyncMock(return_value=[user.id])):
+        created = await service.schedule_session_notifications(session.id, session=session)
+        assert created == 4
+        created_again = await service.schedule_session_notifications(session.id, session=session)
+        assert created_again == 0
+
+    assert await ConcertNoti.filter(session_id=session.id).count() == 4
+
+
+@pytest.mark.asyncio
+async def test_schedule_session_notifications_handles_integrity_error() -> None:
+    user = await User.create(
+        provider=ProviderChoice.KAKAO,
+        provider_id="kakao_integrity",
+        nickname="integrity_user",
+    )
+    concert = await Concert.create(title="Integrity", category=CategoryType.KPOP)
+    session = await ConcertSession.create(concert=concert, session_name="Two", start_at=now_kst())
+
+    service = NotificationService()
+    with (
+        patch.object(service, "_resolve_target_user_ids", new=AsyncMock(return_value=[user.id])),
+        patch(
+            "app.domains.notifications.service.ConcertNoti.bulk_create",
+            new=AsyncMock(side_effect=IntegrityError("dup")),
+        ),
+    ):
+        created = await service.schedule_session_notifications(session.id, session=session)
+        assert created == 4
+
+    assert await ConcertNoti.filter(session_id=session.id).count() == 4
+
+
+@pytest.mark.asyncio
+async def test_schedule_session_notifications_returns_zero_for_ended() -> None:
+    concert = await Concert.create(title="Ended", category=CategoryType.KPOP)
+    session = await ConcertSession.create(
+        concert=concert,
+        session_name="Ended",
+        start_at=now_kst(),
+        status=StreamStatus.ENDED,
+    )
+    service = NotificationService()
+    created = await service.schedule_session_notifications(session.id)
+    assert created == 0
+
+
+@pytest.mark.asyncio
+async def test_schedule_session_notifications_returns_zero_for_no_targets() -> None:
+    concert = await Concert.create(title="NoTarget", category=CategoryType.KPOP)
+    session = await ConcertSession.create(concert=concert, session_name="NoTarget", start_at=now_kst())
+
+    service = NotificationService()
+    with patch.object(service, "_resolve_target_user_ids", new=AsyncMock(return_value=[])):
+        created = await service.schedule_session_notifications(session.id, session=session)
+    assert created == 0
+
+
+@pytest.mark.asyncio
+async def test_schedule_upcoming_sessions_filters_and_calls() -> None:
+    base_time = now_kst()
+    concert = await Concert.create(title="Upcoming", category=CategoryType.KPOP)
+    ready_session = await ConcertSession.create(
+        concert=concert,
+        session_name="Ready",
+        start_at=base_time + timedelta(hours=1),
+    )
+    await ConcertSession.create(
+        concert=concert,
+        session_name="Ended",
+        start_at=base_time + timedelta(hours=1),
+        status=StreamStatus.ENDED,
+    )
+
+    service = NotificationService()
+    dummy_query = _DummyQuery([ready_session])
+    with (
+        patch("app.domains.notifications.service.ConcertSession.filter", return_value=dummy_query),
+        patch.object(service, "schedule_session_notifications", new=AsyncMock(return_value=1)) as mock_sched,
+    ):
+        total = await service.schedule_upcoming_sessions(hours_ahead=2)
+
+    assert total == 1
+    assert mock_sched.await_count == 1
+    call_args = mock_sched.await_args
+    assert call_args.args[0] == ready_session.id
+    assert call_args.kwargs["session"].id == ready_session.id
+
+
+@pytest.mark.asyncio
+async def test_deliver_concert_notification_publishes() -> None:
+    user = await User.create(
+        provider=ProviderChoice.KAKAO,
+        provider_id="kakao_publish",
+        nickname="publish_user",
+    )
+    concert = await Concert.create(title="Deliver", category=CategoryType.KPOP)
+    session = await ConcertSession.create(concert=concert, session_name="Delivery", start_at=now_kst())
+    noti = await ConcertNoti.create(
+        user=user,
+        session=session,
+        kind=NotiKind.START,
+        title="start",
+        message="msg",
+        send_at=now_kst(),
+        status=NotiStatus.PENDING,
+    )
+
+    service = NotificationService()
+    with patch("app.domains.notifications.service.notification_manager.publish", new=AsyncMock()) as mock_pub:
+        ok = await service.deliver_concert_notification(noti)
+
+    assert ok is True
+    mock_pub.assert_awaited_once()
+    args = mock_pub.call_args.args
+    assert args[0] == str(user.id)
+    assert "notification" in args[1]
+
+
+@pytest.mark.asyncio
+async def test_handle_ws_connection_disconnects() -> None:
+    service = NotificationService()
+    ws = AsyncMock()
+    ws.receive_text = AsyncMock(side_effect=WebSocketDisconnect())
+
+    with (
+        patch("app.domains.notifications.service.notification_manager.ensure_subscriber", new=AsyncMock()),
+        patch("app.domains.notifications.service.notification_manager.connect", new=AsyncMock()),
+        patch("app.domains.notifications.service.notification_manager.disconnect", new=AsyncMock()) as mock_disconnect,
+    ):
+        await service.handle_ws_connection(ws, user_id=1)
+
+    mock_disconnect.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_handle_ws_connection_runtime_error_closes() -> None:
+    service = NotificationService()
+    ws = AsyncMock()
+
+    with (
+        patch("app.domains.notifications.service.notification_manager.ensure_subscriber", new=AsyncMock()),
+        patch(
+            "app.domains.notifications.service.notification_manager.connect",
+            new=AsyncMock(side_effect=RuntimeError("busy")),
+        ),
+        patch("app.domains.notifications.service.notification_manager.disconnect", new=AsyncMock()) as mock_disconnect,
+    ):
+        await service.handle_ws_connection(ws, user_id=1)
+
+    ws.close.assert_awaited_once_with(code=1008)
+    mock_disconnect.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_resolve_target_user_ids_combines_filters() -> None:
+    concert = await Concert.create(title="Filters", category=CategoryType.KPOP)
+    session = await ConcertSession.create(concert=concert, session_name="Mix", start_at=now_kst())
+
+    artist = await Artist.create(stage_name="Artist A")
+    await session.lineup.add(artist)
+
+    user1 = await User.create(
+        provider=ProviderChoice.KAKAO,
+        provider_id="kakao_filter_1",
+        nickname="filter1",
+    )
+    await UserNoti.create(user=user1, artist_noti=True, live_noti=True, marketing_noti=False)
+    await user1.followed_artists.add(artist)
+
+    user2 = await User.create(
+        provider=ProviderChoice.KAKAO,
+        provider_id="kakao_filter_2",
+        nickname="filter2",
+    )
+    await UserNoti.create(user=user2, artist_noti=False, live_noti=True, marketing_noti=False)
+    await UserCatFav.create(user=user2, category=CategoryType.KPOP)
+
+    service = NotificationService()
+    user_ids = await service._resolve_target_user_ids(session)
+
+    assert set(user_ids) == {user1.id, user2.id}

--- a/tests/notifications/test_tasks.py
+++ b/tests/notifications/test_tasks.py
@@ -1,0 +1,65 @@
+from datetime import timedelta
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.core.config import now_kst
+from app.domains.notifications.models import ConcertNoti, NotiKind, NotiStatus
+from app.domains.notifications.tasks import _dispatch_due_notifications
+from app.domains.streams.models import Concert, ConcertSession, StreamStatus
+from app.domains.users.models import ProviderChoice, User
+
+
+@pytest.mark.asyncio
+async def test_dispatch_due_notifications_sends_ready_and_live():
+    user = await User.create(
+        provider=ProviderChoice.KAKAO,
+        provider_id="kakao_dispatch",
+        nickname="dispatch_user",
+    )
+    concert = await Concert.create(title="Dispatch Test")
+
+    ready_session = await ConcertSession.create(
+        concert=concert,
+        session_name="ready",
+        start_at=now_kst(),
+    )
+    live_session = await ConcertSession.create(
+        concert=concert,
+        session_name="live",
+        start_at=now_kst(),
+        status=StreamStatus.LIVE,
+    )
+
+    ready_noti = await ConcertNoti.create(
+        user=user,
+        session=ready_session,
+        kind=NotiKind.HOUR_1,
+        title="ready",
+        message="ready",
+        send_at=now_kst() - timedelta(minutes=1),
+    )
+    live_noti = await ConcertNoti.create(
+        user=user,
+        session=live_session,
+        kind=NotiKind.START,
+        title="live",
+        message="live",
+        send_at=now_kst() + timedelta(minutes=30),
+    )
+
+    with patch(
+        "app.domains.notifications.service.notification_manager.publish",
+        new=AsyncMock(),
+    ) as mock_publish:
+        sent = await _dispatch_due_notifications(batch_size=10)
+        assert sent == 2
+        assert mock_publish.await_count == 2
+
+    refreshed_ready = await ConcertNoti.get(id=ready_noti.id)
+    refreshed_live = await ConcertNoti.get(id=live_noti.id)
+
+    assert refreshed_ready.status == NotiStatus.SENT
+    assert refreshed_ready.sent_at is not None
+    assert refreshed_live.status == NotiStatus.SENT
+    assert refreshed_live.sent_at is not None

--- a/tests/notifications/test_ws.py
+++ b/tests/notifications/test_ws.py
@@ -1,0 +1,49 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import FastAPI, WebSocket
+from starlette.routing import WebSocketRoute
+from starlette.testclient import TestClient
+
+from app.api.deps import get_current_user_from_refresh_cookie_ws
+from app.main import app
+
+
+def find_notifications_ws_route(app_: FastAPI) -> WebSocketRoute:
+    ws_routes = [r for r in app_.router.routes if isinstance(r, WebSocketRoute)]
+    for route in ws_routes:
+        if route.path.endswith("/notifications/ws"):
+            return route
+    raise AssertionError(
+        f"notifications WebSocketRoute를 못 찾았음. ws_routes={[r.path for r in ws_routes]}"
+    )
+
+
+@pytest.fixture()
+def ws_client() -> TestClient:
+    client = TestClient(app)
+    yield client
+    client.close()
+
+
+@pytest.fixture(autouse=True)
+def override_ws_user():
+    async def _override(ws: WebSocket) -> SimpleNamespace:
+        return SimpleNamespace(id=1)
+
+    app.dependency_overrides[get_current_user_from_refresh_cookie_ws] = _override
+    yield
+    app.dependency_overrides.clear()
+
+
+def test_notifications_ws_connects(ws_client: TestClient) -> None:
+    route = find_notifications_ws_route(app)
+    with (
+        patch(
+            "app.domains.notifications.service.notification_manager.ensure_subscriber",
+            new=AsyncMock(),
+        ),
+        ws_client.websocket_connect(route.path) as ws,
+    ):
+        ws.send_text("ping")


### PR DESCRIPTION
## ✅ PR 한줄 요약
- 라이브 세션 알림을 DB에 스케줄링하고, Celery Beat/Worker로 기한 도래 알림을 WS로 실시간 발송하도록 알림 파이프라인을 구축

## 🔗 관련 이슈
- Jira: NEAR-67

## 🛠️ 변경 내용
- [x] Celery 앱 설정 추가: Redis broker/backend 사용 + timezone=Asia/Seoul, enable_utc=False, beat_schedule 연결
- [ ] Celery Beat 스케줄 추가 10분마다: schedule_upcoming_session_notifications(hours_ahead=24) 실행 → 다가오는 세션 알림 레코드 생성
- [ ] 알림 이벤트 스키마 추가 NotificationItem(from_attributes=True), NotificationEvent(type="notification")로 WS payload 표준화


## ⚠️ 리뷰 포인트 / 주의사항
- 이게 최선이야...
