### PR TITLE
Near 51 admin concert get patch

### DIFF
--- a/app/domains/streams/admin/router.py
+++ b/app/domains/streams/admin/router.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Body, Depends, Path, Request, status
+from fastapi import APIRouter, Body, Depends, Path, Query, Request, Response, status
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 
@@ -8,6 +8,7 @@ from app.domains.streams.admin.schemas import (
     ConcertResponse,
     SessionCreateRequest,
     SessionResponse,
+    SessionUpdateRequest,
     StreamIngestResponse,
 )
 from app.domains.streams.admin.service import StreamAdminService
@@ -15,7 +16,7 @@ from app.domains.streams.deps import get_admin_user
 from app.domains.streams.models import Concert
 from app.domains.users.models import User
 
-router = APIRouter(prefix="/admin/streams", tags=["[Admin] Streaming"])
+router = APIRouter(prefix="/admin/streams", tags=["[Admin] 스트리밍 관리"])
 templates = Jinja2Templates(directory="templates")
 
 
@@ -56,6 +57,57 @@ async def create_concert_stream(
     return await service.create_session_with_infrastructure(concert_id, data, current_admin)
 
 
+@router.get(
+    "/sessions",
+    response_model=list[SessionResponse],
+    summary="콘서트 세션 목록 조회",
+    description="모든 콘서트 세션을 조회합니다. \
+    AWS IVS의 현재 라이브 상태를 실시간으로 확인하여 목록에 반영합니다.",
+)
+async def list_concert_sessions(
+    response: Response,
+    cursor: int | None = Query(None),
+    limit: int = Query(20, ge=1, le=100),
+    current_admin: User = Depends(get_admin_user),
+    service: StreamAdminService = Depends(streams_deps.get_stream_admin_service),
+) -> list[SessionResponse]:
+    sessions, next_cursor = await service.list_sessions_admin(current_admin, limit, cursor)
+
+    if next_cursor is not None:
+        response.headers["X-Next-Cursor"] = str(next_cursor)
+
+    return sessions
+
+
+@router.get(
+    "/sessions/{session_id}",
+    response_model=SessionResponse,
+    summary="콘서트 세션 상세 조회",
+)
+async def get_concert_session_detail(
+    session_id: int = Path(..., description="조회할 세션 ID"),
+    current_admin: User = Depends(get_admin_user),
+    service: StreamAdminService = Depends(streams_deps.get_stream_admin_service),
+) -> SessionResponse:
+    return await service.get_session_admin_detail(session_id, current_admin)
+
+
+@router.patch(
+    "/sessions/{session_id}",
+    response_model=SessionResponse,
+    summary="콘서트 세션 및 인프라 수정",
+    description="세션 정보와 IVS 설정을 부분 수정합니다. \
+        channel_config 전달 시 AWS 설정도 즉시 변경됩니다.",
+)
+async def update_concert_session(
+    session_id: int = Path(..., description="수정할 세션 ID"),
+    data: SessionUpdateRequest = Body(...),
+    current_admin: User = Depends(get_admin_user),
+    service: StreamAdminService = Depends(streams_deps.get_stream_admin_service),
+) -> SessionResponse:
+    return await service.update_session_infrastructure(session_id, data, current_admin)
+
+
 @router.delete(
     "/sessions/{session_id}",
     status_code=status.HTTP_204_NO_CONTENT,
@@ -74,7 +126,7 @@ async def delete_concert_session(
     "/sessions/{session_id}/rotate-key",
     summary="스트림 키 강제 재발급 (보안)",
     description="기존의 모든 스트림 키를 무효화(삭제)하고 새로운 키 생성 \
-                 스트림 키가 유출되었을 때 사용합니다.",
+                스트림 키가 유출되었을 때 사용합니다.",
 )
 async def rotate_session_stream_key(
     session_id: int = Path(..., description="키를 갱신할 세션 ID"),
@@ -99,6 +151,7 @@ async def stop_live_stream(
     return {"message": "방송이 종료 처리되었습니다."}
 
 
+# ================================= ivs 송출 테스트용 엔드포인트 =================================
 @router.get(
     "/sessions/{session_id}/ingest",
     response_model=StreamIngestResponse,

--- a/app/domains/streams/admin/schemas.py
+++ b/app/domains/streams/admin/schemas.py
@@ -3,7 +3,13 @@ from datetime import datetime
 from pydantic import BaseModel, ConfigDict, Field
 from pydantic.alias_generators import to_camel
 
-from app.domains.streams.models import AccessLevel, CategoryType, ChannelType, LatencyMode
+from app.domains.streams.models import (
+    AccessLevel,
+    CategoryType,
+    ChannelType,
+    LatencyMode,
+    StreamStatus,
+)
 
 # 모든 AWS 통신(In/Out)은 CamelCase, 서버 내부 로직은 snake_case
 COMMON_CONFIG = ConfigDict(
@@ -27,6 +33,12 @@ class StreamLiveMetrics(BaseModel):
     viewer_count: int = Field(..., description="현재 동시 시청자 수")
     start_time: datetime | None = Field(None, description="방송 시작 시각")
     state: str = Field(..., description="LIVE 상태")
+
+
+class IVSUpdateConfig(BaseModel):
+    model_config = COMMON_CONFIG
+    latency_mode: LatencyMode | None = None
+    channel_type: ChannelType | None = Field(None, alias="type")
 
 
 class StreamIngestInfo(BaseModel):
@@ -76,9 +88,20 @@ class SessionCreateRequest(BaseModel):
     channel_config: ChannelConfig = Field(default_factory=ChannelConfig)
 
 
+class SessionUpdateRequest(BaseModel):
+    """세션 수정 요청 스키마"""
+
+    model_config = COMMON_CONFIG
+    session_name: str | None = None
+    start_at: datetime | None = None
+    end_at: datetime | None = None
+    access_level: AccessLevel | None = None
+    is_test: bool | None = None
+    artist_ids: list[int] | None = None  # 라인업
+    channel_config: IVSUpdateConfig | None = None  # IVS  채널 수정
+
+
 # ==================== 응답 스키마 ====================
-
-
 class ConcertResponse(BaseModel):
     """콘서트 생성 응답"""
 
@@ -93,13 +116,15 @@ class ConcertResponse(BaseModel):
 
 
 class SessionResponse(BaseModel):
-    """세션 생성 응답"""
+    """세션 응답"""
 
     model_config = COMMON_CONFIG
     id: int = Field(..., description="내부 세션 ID")
     session_name: str
     access_level: AccessLevel
     start_at: datetime
+
+    status: StreamStatus
 
     # 인프라 정보는 별도 객체로 분리
     channel: IVSChannelSummary | None = None

--- a/app/domains/streams/admin/service.py
+++ b/app/domains/streams/admin/service.py
@@ -1,11 +1,17 @@
+from typing import Literal, cast
+
 from botocore.exceptions import ClientError
 from fastapi import HTTPException
+from mypy_boto3_ivs.type_defs import GetStreamResponseTypeDef
 
+from app.core.pagination import paginate_cursor
 from app.domains.artists.models import Artist
 from app.domains.streams.admin.schemas import (
     ConcertCreateRequest,
+    IVSChannelSummary,
     SessionCreateRequest,
     SessionResponse,
+    SessionUpdateRequest,
     StreamIngestInfo,
     StreamIngestResponse,
     StreamLiveMetrics,
@@ -128,6 +134,7 @@ class StreamAdminService:
             id=session.id,
             session_name=session.session_name,
             access_level=session.access_level,
+            status=session.status,
             start_at=session.start_at,
             channel=IVSChannelSummary(
                 arn=channel.channel_arn,
@@ -207,6 +214,192 @@ class StreamAdminService:
         # DB 상태 업데이트
         session.status = StreamStatus.ENDED
         await session.save(update_fields=["status"])
+
+    async def list_sessions_admin(
+        self, user: User, limit: int = 20, cursor: int | None = None
+    ) -> tuple[list[SessionResponse], int | None]:
+        """
+        [Admin] 라이브 방송 목록 조회
+        """
+        StreamPermission.must_be_admin(user)
+
+        # DB 조회
+        queryset = ConcertSession.all().prefetch_related("stream_channel", "concert")
+        sessions, next_cursor = await paginate_cursor(
+            queryset=queryset, limit=limit, cursor=cursor, order_by="-id"
+        )
+
+        # ENDED가 아닌 세션의 채널 ARN만 수집
+        active_channel_arns = {
+            s.stream_channel.channel_arn
+            for s in sessions
+            if hasattr(s, "stream_channel") and s.stream_channel and s.status != StreamStatus.ENDED
+        }
+        # 활성 채널만 AWS에 조회
+        live_channel_arns = set()
+        if active_channel_arns:
+            try:
+                # 건강 상태 확인
+                live_streams = self.ivs_client.list_live_streams()
+                live_channel_arns = {
+                    s["channelArn"] for s in live_streams if s["channelArn"] in active_channel_arns
+                }
+            except Exception:
+                pass  # AWS 조회 실패해도 DB 목록은 보여줌
+
+        results = []
+        for s in sessions:
+            channel = getattr(s, "stream_channel", None)
+
+            # DB는 READY지만 AWS에서 실제 송출 중이라면 LIVE로 표시
+            display_status = s.status
+            if (
+                channel
+                and (channel.channel_arn in live_channel_arns)
+                and s.status != StreamStatus.ENDED
+            ):
+                display_status = StreamStatus.LIVE
+
+            results.append(
+                SessionResponse(
+                    id=s.id,
+                    session_name=s.session_name,
+                    access_level=s.access_level,
+                    start_at=s.start_at,
+                    status=display_status,
+                    channel=IVSChannelSummary(
+                        arn=channel.channel_arn,
+                        ingest_endpoint=channel.ingest_endpoint,
+                        playback_url=channel.playback_url,
+                        latency_mode=channel.latency_mode,
+                        type=channel.type,
+                    )
+                    if channel
+                    else None,
+                )
+            )
+
+        return results, next_cursor
+
+    async def get_session_admin_detail(self, session_id: int, user: User) -> SessionResponse:
+        """
+        [Admin] 콘서트 세션 상세 조회
+        """
+        StreamPermission.must_be_admin(user)
+        session = await ConcertSession.get_or_none(id=session_id).prefetch_related("stream_channel")
+        if not session:
+            raise HTTPException(404, "해당 콘서트 세션을 찾을 수 없습니다.")
+
+        channel = getattr(session, "stream_channel", None)
+
+        return SessionResponse(
+            id=session.id,
+            session_name=session.session_name,
+            access_level=session.access_level,
+            start_at=session.start_at,
+            status=session.status,
+            channel=IVSChannelSummary(
+                arn=channel.channel_arn,
+                ingest_endpoint=channel.ingest_endpoint,
+                playback_url=channel.playback_url,
+                latency_mode=channel.latency_mode,
+                type=channel.type,
+            )
+            if channel
+            else None,
+        )
+
+    async def update_session_infrastructure(
+        self, session_id: int, data: SessionUpdateRequest, user: User
+    ) -> SessionResponse:
+        """
+        [Admin] 콘서트 세션 수정
+        """
+        StreamPermission.must_be_admin(user)
+
+        # 동시 수정 방지 Lock
+        session = (
+            await ConcertSession.filter(id=session_id)
+            .select_for_update()
+            .prefetch_related("stream_channel")
+            .first()
+        )
+        if not session:
+            raise HTTPException(404, "해당 콘서트 세션을 찾을 수 없습니다.")
+
+        channel = getattr(session, "stream_channel", None)
+
+        # DB 수정
+        update_dict = data.model_dump(exclude={"channel_config", "artist_ids"}, exclude_unset=True)
+        for key, value in update_dict.items():
+            setattr(session, key, value)
+
+        # 아티스트 정보 수정
+        if data.artist_ids is not None:
+            # 기존 매핑 삭제 후 재생성
+            await ConcertArtist.filter(session=session).delete()
+            if data.artist_ids:
+                artists = await Artist.filter(id__in=data.artist_ids)
+                for artist in artists:
+                    await ConcertArtist.create(session=session, artist=artist)
+
+        # AWS IVS 채널 설정 동기화
+        if data.channel_config and channel:
+            config = data.channel_config
+
+            # Private 여부 결정
+            current_access = update_dict.get("access_level", session.access_level)
+            is_private = current_access != AccessLevel.PUBLIC
+
+            # 변경할 값 확인 (없으면 기존 값 유지)
+            new_latency = cast(
+                "Literal['LOW', 'NORMAL']",
+                config.latency_mode.value if config.latency_mode else channel.latency_mode.value,
+            )
+            new_type = cast(
+                "Literal['ADVANCED_HD', 'ADVANCED_SD', 'BASIC', 'STANDARD']",
+                config.channel_type.value if config.channel_type else channel.type.value,
+            )
+
+            # AWS API 호출
+            self.ivs_client.update_channel(
+                channel_arn=channel.channel_arn,  # type: ignore
+                name=f"session-{session.id}",  # 이름 강제 동기화
+                latencyMode=new_latency,
+                type=new_type,
+                authorized=is_private,
+            )
+
+            # DB 채널 정보 업데이트
+            if config.latency_mode:
+                channel.latency_mode = config.latency_mode
+            if config.channel_type:
+                channel.type = config.channel_type
+            channel.is_private = is_private
+            await channel.save()
+
+        await session.save()
+
+        # 업데이트된 정보로 다시 조회하여 반환
+        return await self.get_session_admin_detail(session_id, user)
+
+    async def _sync_session_status_with_aws(
+        self, session: ConcertSession, channel: StreamChannel
+    ) -> tuple[StreamStatus, GetStreamResponseTypeDef | None]:
+        """AWS 실시간 상태와 DB 상태 동기화"""
+        stream_res = self.ivs_client.get_stream_health(channel.channel_arn)
+        is_live = stream_res is not None and "stream" in stream_res
+
+        new_status = StreamStatus.LIVE if is_live else StreamStatus.READY
+
+        # ENDED 상태는 보존
+        if session.status != StreamStatus.ENDED and session.status != new_status:
+            session.status = new_status
+            await session.save(update_fields=["status"])
+
+        return session.status, stream_res
+
+    # ================================= ivs 송출 테스트용  =================================
 
     async def get_stream_ingest_info(self, session_id: int, user: User) -> StreamIngestResponse:
         """

--- a/tests/streams/admin/test_get_and_update_session.py
+++ b/tests/streams/admin/test_get_and_update_session.py
@@ -1,0 +1,213 @@
+from datetime import datetime, timedelta
+
+import pytest
+from fastapi import HTTPException
+
+from app.domains.streams.admin.schemas import SessionUpdateRequest
+from app.domains.streams.admin.service import StreamAdminService
+from app.domains.streams.models import (
+    AccessLevel,
+    CategoryType,
+    ChannelType,
+    Concert,
+    ConcertSession,
+    LatencyMode,
+    StreamChannel,
+    StreamStatus,
+)
+from app.domains.users.models import ProviderChoice, User
+from app.integrations.aws_ivs import IVSClient, IVSPlaybackProvider
+
+
+@pytest.fixture
+def admin_service():
+    return StreamAdminService(
+        ivs_client=IVSClient(),
+        playback_provider=IVSPlaybackProvider(),
+    )
+
+
+@pytest.fixture
+async def admin_user():
+    return await User.create(
+        id=1,
+        provider=ProviderChoice.KAKAO,
+        provider_id="test-admin-1",
+        nickname="admin",
+        is_superuser=True,
+    )
+
+
+@pytest.fixture
+async def concert():
+    return await Concert.create(
+        title="테스트 콘서트",
+        category=CategoryType.KPOP,
+        description="test",
+    )
+
+
+@pytest.fixture
+async def session_with_channel(concert):
+    session = await ConcertSession.create(
+        concert=concert,
+        session_name="1회차",
+        start_at=datetime.utcnow() + timedelta(hours=1),
+        status=StreamStatus.READY,
+        access_level=AccessLevel.PUBLIC,
+    )
+
+    await StreamChannel.create(
+        session=session,
+        channel_arn="arn:ivs:test:channel/1",
+        ingest_endpoint="rtmp://test",
+        playback_url="https://playback.m3u8",
+        type=ChannelType.STANDARD,
+        latency_mode=LatencyMode.LOW,
+        is_private=False,
+        stream_key_encrypted="dummy",
+    )
+    return session
+
+
+@pytest.mark.asyncio
+async def test_list_sessions_admin_live_overrides_db(
+    admin_service, admin_user, session_with_channel, monkeypatch
+):
+    service = admin_service
+
+    def fake_list_live_streams():
+        return [{"channelArn": "arn:ivs:test:channel/1"}]
+
+    monkeypatch.setattr(
+        service.ivs_client,
+        "list_live_streams",
+        fake_list_live_streams,
+    )
+
+    results, next_cursor = await service.list_sessions_admin(admin_user)
+
+    assert next_cursor is None
+    assert len(results) == 1
+    assert results[0].status == StreamStatus.LIVE
+
+
+@pytest.mark.asyncio
+async def test_list_sessions_admin_aws_failure_fallback(
+    admin_service, admin_user, session_with_channel, monkeypatch
+):
+    service = admin_service
+
+    def raise_error():
+        raise Exception("AWS down")
+
+    monkeypatch.setattr(
+        service.ivs_client,
+        "list_live_streams",
+        raise_error,
+    )
+
+    results, _ = await service.list_sessions_admin(admin_user)
+
+    assert results[0].status == StreamStatus.READY
+
+
+@pytest.mark.asyncio
+async def test_get_session_admin_detail_success(admin_service, admin_user, session_with_channel):
+    service = admin_service
+
+    res = await service.get_session_admin_detail(
+        session_with_channel.id,
+        admin_user,
+    )
+
+    assert res.id == session_with_channel.id
+    assert res.channel is not None
+    assert res.channel.arn == "arn:ivs:test:channel/1"
+
+
+@pytest.mark.asyncio
+async def test_get_session_admin_detail_not_found(admin_service, admin_user):
+    service = admin_service
+
+    with pytest.raises(HTTPException) as exc:
+        await service.get_session_admin_detail(999, admin_user)
+
+    assert exc.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_update_session_updates_db_and_calls_aws(
+    admin_service, admin_user, session_with_channel, monkeypatch
+):
+    service = admin_service
+    called = {}
+
+    def fake_update_channel(**kwargs):
+        called["yes"] = True
+        return {}
+
+    monkeypatch.setattr(
+        service.ivs_client,
+        "update_channel",
+        fake_update_channel,
+    )
+
+    data = SessionUpdateRequest(
+        session_name="수정됨",
+        access_level=AccessLevel.ADMIN_ONLY,
+        channel_config={"latencyMode": LatencyMode.NORMAL},
+    )
+
+    res = await service.update_session_infrastructure(
+        session_with_channel.id,
+        data,
+        admin_user,
+    )
+
+    assert called.get("yes") is True
+    assert res.session_name == "수정됨"
+    assert res.access_level == AccessLevel.ADMIN_ONLY
+
+
+@pytest.mark.asyncio
+async def test_sync_session_status_to_live(admin_service, session_with_channel, monkeypatch):
+    service = admin_service
+
+    monkeypatch.setattr(
+        service.ivs_client,
+        "get_stream_health",
+        lambda arn: {"stream": {"state": "LIVE"}},
+    )
+
+    channel = await session_with_channel.stream_channel.first()
+
+    status, res = await service._sync_session_status_with_aws(
+        session_with_channel,
+        channel,
+    )
+
+    assert status == StreamStatus.LIVE
+    assert res is not None
+
+
+@pytest.mark.asyncio
+async def test_sync_does_not_override_ended(admin_service, session_with_channel, monkeypatch):
+    service = admin_service
+    session_with_channel.status = StreamStatus.ENDED
+    await session_with_channel.save()
+
+    monkeypatch.setattr(
+        service.ivs_client,
+        "get_stream_health",
+        lambda arn: {"stream": {}},
+    )
+
+    channel = await session_with_channel.stream_channel.first()
+
+    status, _ = await service._sync_session_status_with_aws(
+        session_with_channel,
+        channel,
+    )
+
+    assert status == StreamStatus.ENDED

--- a/tests/streams/admin/test_router.py
+++ b/tests/streams/admin/test_router.py
@@ -5,7 +5,7 @@ import pytest
 from httpx import ASGITransport, AsyncClient
 
 from app.domains.streams.deps import get_admin_user
-from app.domains.streams.models import AccessLevel, ChannelType, LatencyMode
+from app.domains.streams.models import AccessLevel, ChannelType, LatencyMode, StreamStatus
 from app.main import app
 
 
@@ -87,6 +87,7 @@ class TestStreamRouter:
                     session_name="Session 1",
                     access_level=AccessLevel.PUBLIC,
                     start_at=datetime.now(),
+                    status=StreamStatus.READY,
                     channel=IVSChannelSummary(
                         arn="arn:test",
                         ingest_endpoint="rtmps://test",

--- a/tests/streams/admin/test_service.py
+++ b/tests/streams/admin/test_service.py
@@ -80,6 +80,7 @@ class TestStreamService:
             mock_session.access_level = AccessLevel.PUBLIC
             mock_session.start_at = now
             mock_sess_create.return_value = mock_session
+            mock_session.status = StreamStatus.READY
 
             mock_art_filter.return_value = [MagicMock(id=1)]
 


### PR DESCRIPTION
## ✅ PR 한줄 요약
- 어드민 콘서트 세션 목록/상세 조회, 수정 엔드포인트 구현

## 🔗 관련 이슈
- Jira: NEAR-51

## 🛠️ 변경 내용
- [x] 라우터 tag 한국어로 변경
- [x] 어드민 콘서트 세션 목록 조회
- [x] 어드민 콘서트 세션 상세 조회
- [x] 어드민 콘서트 세션 수정

## 🧪 테스트
- [x] 로컬 테스트 완료 (`uv run pytest -q`)
- [x] ruff/mypy 통과 확인
  - [x] `uv run ruff check .`
  - [x] `uv run ruff format --check .`
  - [x] `uv run mypy .`
