### PR TITLE
Near 98 del internal token logic

### DIFF
--- a/app/domains/streams/client/router.py
+++ b/app/domains/streams/client/router.py
@@ -1,7 +1,7 @@
 from datetime import date
 from typing import Annotated, Any
 
-from fastapi import APIRouter, Body, Depends, Path
+from fastapi import APIRouter, Depends, Path
 from fastapi.params import Query
 
 from app.api import deps
@@ -15,13 +15,13 @@ from app.domains.streams.client.service import StreamUserService
 from app.domains.streams.models import CategoryType, StreamStatus
 from app.domains.users.models import User
 
-router = APIRouter(prefix="/streams", tags=["Streaming"])
+router = APIRouter(prefix="/streams", tags=["스트리밍"])
 
 
 @router.get(
     "/sessions/{session_id}/credentials",
     summary="스트림 시청 권한 확인 - 토큰 발급",
-    description="실시간 스트리밍 시청을 위한 Playback URL과 인증 토큰을 발급합니다. \
+    description="실시간 스트리밍 시청을 위한 Playback URL을 발급합니다. \
                 \n\n 비공개 채널의 경우 IVS Playback Token이 포함됩니다.",
 )
 async def get_stream_access(
@@ -30,9 +30,7 @@ async def get_stream_access(
     service: StreamUserService = Depends(streams_deps.get_stream_user_service),
 ) -> dict[str, Any]:
     """
-    1. 유저의 세션 시청 자격(티켓 등)을 검증합니다.
-    2. AWS IVS 채널 설정에 따라 Playback Token 서명 여부를 결정합니다.
-    3. 채팅 서버 인증을 위한 내부 세션 토큰을 함께 반환합니다.
+    AWS IVS 채널 설정에 따라 Playback Token 서명 여부를 결정합니다.
     """
     return await service.get_viewing_credentials(session_id, current_user)
 
@@ -40,24 +38,17 @@ async def get_stream_access(
 @router.post(
     "/sessions/{session_id}/refresh",
     summary="시청 세션 연장 (토큰 재발급)",
-    description="시청 중 토큰이 만료되기 전, 기존 리프레시 토큰을 사용해 세션을 연장합니다. \
-                 \n\n 이때 유저의 시청 자격을 재검증합니다.",
+    description="시청 중 토큰이 만료 시 호출할 API 입니다.\
+                \n\n새로운 유효기간을 가진 AWS IVS 재생 토큰을 발급받아 Playback URL을 반환합니다.\
+                \n\n비공개 채널의 경우에만 IVS Playback Token이 포함됩니다.",
 )
-async def refresh_stream_session(
+async def get_refresh_url(
     session_id: int = Path(..., description="콘서트 세션 ID"),
-    refresh_token: str = Body(..., embed=True),  # json body에서 refresh_token 추출
     current_user: User = Depends(deps.get_current_user),
     service: StreamUserService = Depends(streams_deps.get_stream_user_service),
 ) -> dict[str, Any]:
-    """
-    1. 유저의 리프레시 토큰을 검증하고 새로운 Access/Refresh 토큰 세트를 생성합니다.
-    2. 동시에 새로운 유효기간을 가진 AWS IVS 재생 토큰을 발급받아 반환합니다.
-    """
-    return await service.refresh_viewing_session(
-        session_id,
-        current_user,
-        refresh_token,
-    )
+    new_url = await service.refresh_playback_url(session_id, current_user)
+    return {"playback_url": new_url}
 
 
 @router.get(

--- a/app/domains/streams/client/service.py
+++ b/app/domains/streams/client/service.py
@@ -42,21 +42,16 @@ class StreamUserService:
             )
             playback_url = f"{playback_url}?token={token}"
 
-        # 내부 세션 토큰
-        internal_tokens = self.playback_provider.sign_internal_tokens(
-            user_id=str(user.id), stream_id=str(channel.id)
-        )
-
         return {
             "playback_url": playback_url,
             "stream_id": channel.id,
-            "access_token": internal_tokens["access_token"],
-            "refresh_token": internal_tokens["refresh_token"],
         }
 
-    async def refresh_viewing_session(
-        self, session_id: int, user: User, refresh_token: str
-    ) -> dict[str, Any]:
+    async def refresh_playback_url(
+        self,
+        session_id: int,
+        user: User,
+    ) -> str:
         """
         [User] 시청 중인 세션 연장 (아마존 권장: 연장 시마다 권한 재검증)
         """
@@ -66,29 +61,23 @@ class StreamUserService:
         if not session:
             raise HTTPException(404, "콘서트 세션 정보를 찾을 수 없습니다.")
 
-        try:
-            # 갱신 시점에 다시 권한 체크
-            await StreamPermission.verify_playback_access(user, session)
-            # 기존 리프레시 토큰으로 새 토큰 Access/Refresh 발급
-            new_tokens = self.playback_provider.rotate_tokens(refresh_token)
-        except Exception:
-            raise HTTPException(401, "유효하지 않거나 만료된 리프레시 토큰입니다.") from None
+        # 갱신 시점에 다시 권한 체크
+        await StreamPermission.verify_playback_access(user, session)
+        channel = session.stream_channel
 
-        # IVS 재생 토큰 새 유효기간으로 재서명
-        channel: StreamChannel = session.stream_channel
-        playback_url: str = channel.playback_url
+        # 공개 채널이면 그냥 URL 반환
+        if not channel.is_private:
+            return channel.playback_url
 
-        if channel.is_private:
-            token = self.playback_provider.sign_playback_token(
-                channel_arn=channel.channel_arn, viewer_id=str(user.id)
-            )
-            playback_url = f"{playback_url}?token={token}"
+        # 비공개 채널이면 토큰 서명
+        new_token = self.playback_provider.sign_playback_token(
+            channel_arn=session.stream_channel.channel_arn,
+            viewer_id=str(user.id),
+            duration_sec=3600,  # 1시간 유효
+        )
+        refreshed_playback_url = f"{channel.playback_url}?token={new_token}"
 
-        return {
-            "playback_url": playback_url,
-            "access_token": new_tokens["access_token"],
-            "refresh_token": new_tokens["refresh_token"],
-        }
+        return refreshed_playback_url
 
     async def list_sessions(
         self,

--- a/app/integrations/aws_ivs/playback.py
+++ b/app/integrations/aws_ivs/playback.py
@@ -1,8 +1,7 @@
 import time
-from typing import Any, Literal, TypedDict, cast
+from typing import TypedDict
 
 import jwt
-from jwt.exceptions import InvalidTokenError
 
 from app.core.config import settings
 
@@ -17,16 +16,6 @@ class IVSPlaybackPayload(TypedDict):
     # "aws:viewer-id": str
 
 
-class InternalTokenPayload(TypedDict):
-    """우리 서비스 내부 인증용 페이로드 (HS256)"""
-
-    sub: str  # User ID
-    stream_id: str  # 방송 PK
-    type: Literal["access", "refresh"]
-    iat: int
-    exp: int
-
-
 class IVSPlaybackProvider:
     """
     AWS IVS 재생 토큰 및 내부 세션 토큰의 생명주기를 관리하는 프로바이더
@@ -35,7 +24,6 @@ class IVSPlaybackProvider:
     def __init__(self) -> None:
         self._secret = settings.SECRET_KEY
         self._ivs_private_key = settings.IVS_PLAYBACK_PRIVATE_KEY
-        self._algo_internal = "HS256"
         self._algo_ivs = "ES384"
 
     # ===================== playback_token 발급 =====================
@@ -60,90 +48,3 @@ class IVSPlaybackProvider:
         }
         # ECDSA P-384 알고리즘으로 서명
         return jwt.encode(payload, self._ivs_private_key, algorithm=self._algo_ivs)
-
-    def sign_internal_tokens(self, user_id: str, stream_id: str) -> dict[str, str]:
-        """
-        [내부 세션] Access & Refresh 토큰 세트 발급 (HS256)
-        - Access: 채팅/API 접근용 (단기)
-        - Refresh: 토큰 재발급용 (장기)
-        """
-        now = int(time.time())
-
-        access_exp = now + (30 * 60)  # 30분
-        refresh_exp = now + (7 * 24 * 3600)  # 7일
-
-        def _encode(payload: dict[str, Any]) -> str:
-            return jwt.encode(payload, self._secret, algorithm=self._algo_internal)
-
-        return {
-            "access_token": _encode(
-                {
-                    "sub": user_id,
-                    "stream_id": stream_id,
-                    "type": "access",
-                    "iat": now,
-                    "exp": access_exp,
-                }
-            ),
-            "refresh_token": _encode(
-                {
-                    "sub": user_id,
-                    "stream_id": stream_id,
-                    "type": "refresh",
-                    "iat": now,
-                    "exp": refresh_exp,
-                }
-            ),
-        }
-
-    # ===================== playback_token 검증 =====================
-
-    def verify_internal_token(
-        self, token: str, expected_type: Literal["access", "refresh"]
-    ) -> InternalTokenPayload:
-        """
-        [내부 세션] 토큰의 기술적 유효성 및 타입을 검증
-        - 서명 위조, 만료 여부, 토큰 용도(access/refresh) 확인
-        """
-        try:
-            decoded = jwt.decode(token, self._secret, algorithms=[self._algo_internal])
-            payload = cast("InternalTokenPayload", decoded)
-
-            if payload.get("type") != expected_type:
-                raise ValueError(f"토큰 타입 불일치: {expected_type} 필요")
-
-            return payload
-        except jwt.ExpiredSignatureError:
-            raise ValueError("토큰이 만료되었습니다.") from None
-        except InvalidTokenError as e:
-            raise ValueError(f"유효하지 않은 토큰입니다: {str(e)}") from e
-
-    # ===================== playback_token 재발급 =====================
-
-    def rotate_tokens(self, refresh_token: str) -> dict[str, str]:
-        """
-        [내부 세션] Access와 Refresh 토큰을 모두 새로 발급 (Refresh Token Rotation)
-        """
-        payload = self.verify_internal_token(refresh_token, expected_type="refresh")
-        # 기존 페이로드 정보를 바탕으로 새 토큰(Access + Refresh) 발급
-        return self.sign_internal_tokens(user_id=payload["sub"], stream_id=payload["stream_id"])
-
-    # ===================================================
-
-    def get_internal_token_remaining_time(self, token: str) -> int:
-        """
-        [Internal Token 전용] 만료까지 남은 시간(초)
-        """
-        try:
-            decoded = jwt.decode(
-                token,
-                self._secret,
-                algorithms=[self._algo_internal],
-                options={"verify_exp": False},
-            )
-            exp = decoded.get("exp")
-            if not isinstance(exp, int):
-                return 0
-            return max(0, exp - int(time.time()))
-        except InvalidTokenError:
-            return 0

--- a/tests/integrations/aws_ivs/test_playback.py
+++ b/tests/integrations/aws_ivs/test_playback.py
@@ -1,4 +1,3 @@
-
 import jwt
 import pytest
 

--- a/tests/integrations/aws_ivs/test_playback.py
+++ b/tests/integrations/aws_ivs/test_playback.py
@@ -1,4 +1,3 @@
-import time
 
 import jwt
 import pytest
@@ -18,41 +17,3 @@ class TestIVSPlaybackProvider:
         decoded = jwt.decode(token, provider._ivs_private_key, algorithms=["ES384"])
         assert decoded["aws:channel-arn"] == "arn:aws:ivs:test"
         assert decoded["aws:viewer-id"] == "viewer1"
-
-    def test_internal_token_full_cycle(self, provider):
-        # 토큰 발급
-        tokens = provider.sign_internal_tokens("user1", "stream1")
-
-        # 검증 (정상)
-        payload = provider.verify_internal_token(tokens["access_token"], expected_type="access")
-        assert payload["sub"] == "user1"
-
-        # 토큰 타입 불일치 에러
-        with pytest.raises(ValueError, match="토큰 타입 불일치"):
-            provider.verify_internal_token(tokens["access_token"], expected_type="refresh")
-
-        # 만료된 토큰 처리
-        expired_payload = {
-            "sub": "u",
-            "stream_id": "s",
-            "type": "access",
-            "iat": int(time.time()) - 4000,
-            "exp": int(time.time()) - 1000,
-        }
-        expired_token = jwt.encode(expired_payload, provider._secret, algorithm="HS256")
-        with pytest.raises(ValueError, match="토큰이 만료되었습니다"):
-            provider.verify_internal_token(expired_token, "access")
-
-        # 유효하지 않은 토큰
-        with pytest.raises(ValueError, match="유효하지 않은 토큰입니다"):
-            provider.verify_internal_token("invalid.token.here", "access")
-
-        # 토큰 재발급
-        time.sleep(1.1)  # iat 변경 보장
-        new_tokens = provider.rotate_tokens(tokens["refresh_token"])
-        assert tokens["access_token"] != new_tokens["access_token"]
-
-        # 남은 시간 조회
-        rem = provider.get_internal_token_remaining_time(tokens["access_token"])
-        assert 1700 < rem <= 1800
-        assert provider.get_internal_token_remaining_time("wrong") == 0

--- a/tests/streams/client/test_service.py
+++ b/tests/streams/client/test_service.py
@@ -60,12 +60,14 @@ class TestStreamService:
             res_pub = await service.get_viewing_credentials(session.id, mock_user)
             assert "token=" not in res_pub["playback_url"]
 
-    async def test_refresh_viewing_session_full(self, service, mock_pb):
-        """시청 세션 연장"""
+    @pytest.mark.asyncio
+    async def test_refresh_playback_url_success(self, service, mock_pb):
+        """시청 세션 연장 및 Playback URL 재발급 테스트"""
         concert = await Concert.create(title="Refresh Test")
         session = await ConcertSession.create(
             concert=concert, session_name="S1", start_at=datetime.now()
         )
+        # StreamChannel 생성 시 playback_url 설정
         await StreamChannel.create(
             id=session.id,
             session=session,
@@ -80,10 +82,49 @@ class TestStreamService:
         with patch(
             "app.domains.streams.permissions.StreamPermission.verify_playback_access",
             new_callable=AsyncMock,
+        ) as mock_verify:
+            res_url = await service.refresh_playback_url(session.id, mock_user)
+
+            mock_verify.assert_called_once()
+
+            assert res_url == "https://test.com?token=signed_token"
+
+            # mock_pb에 전달된 인자 검증
+            mock_pb.sign_playback_token.assert_called_with(
+                channel_arn="arn:ivs:test2",  # DB에 저장한 값
+                viewer_id="1",
+                duration_sec=3600,
+            )
+
+    @pytest.mark.asyncio
+    async def test_refresh_playback_url_public_channel(self, service, mock_pb):
+        """공개 채널일 경우 토큰 없이 URL만 반환하는지 테스트"""
+        concert = await Concert.create(title="Public Test")
+        session = await ConcertSession.create(
+            concert=concert, session_name="S2", start_at=datetime.now()
+        )
+
+        # 공개(is_private=False) 채널 생성
+        await StreamChannel.create(
+            id=session.id,
+            session=session,
+            playback_url="https://public.playback.com/index.m3u8",
+            channel_arn="arn:aws:ivs:public",
+            ingest_endpoint="rtmps://public.ingest.com",
+            stream_key_encrypted="key",
+            is_private=False,
+        )
+
+        mock_user = MagicMock(id=1)
+        with patch(
+            "app.domains.streams.permissions.StreamPermission.verify_playback_access",
+            new_callable=AsyncMock,
         ):
-            res = await service.refresh_viewing_session(session.id, mock_user, "old_rt")
-            assert res["access_token"] == "new_at"
-            assert "token=signed_token" in res["playback_url"]
+            res_url = await service.refresh_playback_url(session.id, mock_user)
+
+            # 검증: 토큰 없이 순수 URL만 반환되어야 함
+            assert res_url == "https://public.playback.com/index.m3u8"
+            mock_pb.sign_playback_token.assert_not_called()
 
     async def test_list_sessions_all_filters(self, service):
         """목록 조회 필터링 검증"""
@@ -146,39 +187,6 @@ class TestStreamService:
         with pytest.raises(HTTPException) as exc:
             await service.get_viewing_credentials(9999, user)
         assert exc.value.status_code == 404
-
-    async def test_refresh_viewing_session_invalid_token(self, service, mock_pb):
-        """잘못된 refresh_token -> 401"""
-        concert = await Concert.create(title="Refresh Invalid")
-        session = await ConcertSession.create(
-            concert=concert,
-            session_name="S1",
-            status=StreamStatus.LIVE,
-            start_at=datetime.now(),
-            end_at=datetime.now() + timedelta(hours=1),
-        )
-        await StreamChannel.create(
-            id=session.id,
-            session=session,
-            playback_url="https://test.com",
-            channel_arn="arn:ivs:test2",
-            ingest_endpoint="https://ingest2.com",
-            stream_key_encrypted="key",
-            is_private=True,
-        )
-
-        user = MagicMock(id=1)
-        # rotate_tokens에서 Exception 발생시키기
-        mock_pb.rotate_tokens.side_effect = Exception("Invalid")
-        service.playback_provider = mock_pb
-
-        with patch(
-            "app.domains.streams.permissions.StreamPermission.verify_playback_access",
-            new_callable=AsyncMock,
-        ):
-            with pytest.raises(HTTPException) as exc:
-                await service.refresh_viewing_session(session.id, user, "bad_rt")
-            assert exc.value.status_code == 401
 
     async def test_get_sessions_detail_not_found(self, service):
         user = MagicMock(id=1)


### PR DESCRIPTION
## ✅ PR 한줄 요약
- 내부용 토큰을 제거하고 ivs 제공 playback token만 사용하도록 변경

## 🔗 관련 이슈
- Jira: NEAR-98

## 🛠️ 변경 내용
- [x] 내부용 토큰 로직 제거
- [x] aws 토큰 이용 리프레시로 변경

## 🧪 테스트
- [x] 로컬 테스트 완료 (`uv run pytest -q`)
- [x] ruff/mypy 통과 확인
  - [x] `uv run ruff check .`
  - [x] `uv run ruff format --check .`
  - [x] `uv run mypy .`