### PR TITLE
Near 97 session noti settings retrieve create

### DIFF
--- a/app/domains/notifications/router.py
+++ b/app/domains/notifications/router.py
@@ -2,10 +2,7 @@ from fastapi import APIRouter, Depends, Query, WebSocket, status
 
 from app.api.deps import get_current_user, get_current_user_from_refresh_cookie_ws
 from app.domains.notifications.models import NotiStatus
-from app.domains.notifications.schemas import (
-    NotificationListResponse,
-    NotificationSettingsResponse
-)
+from app.domains.notifications.schemas import NotificationListResponse, NotificationSettingsResponse
 from app.domains.notifications.service import notification_service
 from app.domains.users.models import User
 
@@ -36,8 +33,8 @@ async def list_notifications(
 async def get_settings(
     current_user: User = Depends(get_current_user),
 ) -> NotificationSettingsResponse:
-    return await notification_service.get_user_settings(current_user.id)
-
+    settings = await notification_service.get_user_settings(current_user.id)
+    return NotificationSettingsResponse.model_validate(settings)
 
 
 @router.websocket("/ws")

--- a/app/domains/notifications/router.py
+++ b/app/domains/notifications/router.py
@@ -2,7 +2,10 @@ from fastapi import APIRouter, Depends, Query, WebSocket, status
 
 from app.api.deps import get_current_user, get_current_user_from_refresh_cookie_ws
 from app.domains.notifications.models import NotiStatus
-from app.domains.notifications.schemas import NotificationListResponse
+from app.domains.notifications.schemas import (
+    NotificationListResponse,
+    NotificationSettingsResponse
+)
 from app.domains.notifications.service import notification_service
 from app.domains.users.models import User
 
@@ -23,6 +26,18 @@ async def list_notifications(
         offset=offset,
     )
     return NotificationListResponse(total=total, items=items)
+
+
+@router.get(
+    "/settings",
+    response_model=NotificationSettingsResponse,
+    status_code=status.HTTP_200_OK,
+)
+async def get_settings(
+    current_user: User = Depends(get_current_user),
+) -> NotificationSettingsResponse:
+    return await notification_service.get_user_settings(current_user.id)
+
 
 
 @router.websocket("/ws")

--- a/app/domains/notifications/schemas.py
+++ b/app/domains/notifications/schemas.py
@@ -6,6 +6,15 @@ from pydantic import BaseModel, ConfigDict
 from app.domains.notifications.models import NotiKind, NotiStatus
 
 
+class NotificationSettingsResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    artist_noti: bool
+    live_noti: bool
+    marketing_noti: bool
+    updated_at: datetime
+
+
 class NotificationItem(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 

--- a/app/domains/notifications/service.py
+++ b/app/domains/notifications/service.py
@@ -9,7 +9,7 @@ from tortoise.expressions import Q
 
 from app.core.config import KST, now_kst
 from app.domains.notifications.manager import notification_manager
-from app.domains.notifications.models import ConcertNoti, NotiKind, NotiStatus
+from app.domains.notifications.models import ConcertNoti, NotiKind, NotiStatus, UserNoti
 from app.domains.notifications.schemas import (
     NotificationEvent,
     NotificationItem,
@@ -56,6 +56,12 @@ def _build_content(session: ConcertSession, kind: NotiKind) -> tuple[str, str]:
 
 
 class NotificationService:
+    async def get_user_settings(self, user_id: int) -> UserNoti:
+        noti = await UserNoti.get_or_none(user_id=user_id)
+        if noti:
+            return noti
+        return await UserNoti.create(user_id=user_id)
+
     async def list_user_notifications(
         self,
         user_id: int,

--- a/app/domains/notifications/service.py
+++ b/app/domains/notifications/service.py
@@ -57,10 +57,11 @@ def _build_content(session: ConcertSession, kind: NotiKind) -> tuple[str, str]:
 
 class NotificationService:
     async def get_user_settings(self, user_id: int) -> UserNoti:
-        noti = await UserNoti.get_or_none(user_id=user_id)
-        if noti:
+        try:
+            noti, _ = await UserNoti.get_or_create(user_id=user_id)
             return noti
-        return await UserNoti.create(user_id=user_id)
+        except IntegrityError:
+            return await UserNoti.get(user_id=user_id)
 
     async def list_user_notifications(
         self,
@@ -71,7 +72,7 @@ class NotificationService:
         offset: int,
     ) -> tuple[list[ConcertNoti], int]:
         query = ConcertNoti.filter(user_id=user_id)
-        if status:
+        if status is not None:
             query = query.filter(status=status)
         total = await query.count()
         items = await query.order_by("-send_at").offset(offset).limit(limit)


### PR DESCRIPTION
## ✅ PR 한줄 요약
- 무엇을/왜 했는지 한 문장으로 적어주세요.

## 🔗 관련 이슈
- Jira: NEAR-97

## 🛠️ 변경 내용
- [ ] notifications/router.py : 알림 사용자 설정 조회/생성 엔드포인트 추가
- [ ] notifications/schemas.py : 알림 사용자 설정 조회/생성 응답 스키마 추가
- [ ] notifications/service.py : 알림 사용자 설정 조회/생성 서비스 로직 구현

## ⚠️ 리뷰 포인트 / 주의사항
- 없음
