### PR TITLE
Near 99 session noti settings update

### DIFF
--- a/app/domains/notifications/router.py
+++ b/app/domains/notifications/router.py
@@ -29,6 +29,18 @@ async def list_notifications(
     return NotificationListResponse(total=total, items=items)
 
 
+@router.delete(
+    "/{notification_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def delete_notification(
+    notification_id: int,
+    current_user: User = Depends(get_current_user),
+) -> None:
+    await notification_service.delete_user_notification(current_user.id, notification_id)
+    return None
+
+
 @router.get(
     "/settings",
     response_model=NotificationSettingsResponse,

--- a/app/domains/notifications/router.py
+++ b/app/domains/notifications/router.py
@@ -2,7 +2,11 @@ from fastapi import APIRouter, Depends, Query, WebSocket, status
 
 from app.api.deps import get_current_user, get_current_user_from_refresh_cookie_ws
 from app.domains.notifications.models import NotiStatus
-from app.domains.notifications.schemas import NotificationListResponse, NotificationSettingsResponse
+from app.domains.notifications.schemas import (
+    NotificationListResponse,
+    NotificationSettingsResponse,
+    NotificationSettingsUpdate,
+)
 from app.domains.notifications.service import notification_service
 from app.domains.users.models import User
 
@@ -34,6 +38,19 @@ async def get_settings(
     current_user: User = Depends(get_current_user),
 ) -> NotificationSettingsResponse:
     settings = await notification_service.get_user_settings(current_user.id)
+    return NotificationSettingsResponse.model_validate(settings)
+
+
+@router.patch(
+    "/settings",
+    response_model=NotificationSettingsResponse,
+    status_code=status.HTTP_200_OK,
+)
+async def update_settings(
+    data: NotificationSettingsUpdate,
+    current_user: User = Depends(get_current_user),
+) -> NotificationSettingsResponse:
+    settings = await notification_service.update_user_settings(current_user.id, data)
     return NotificationSettingsResponse.model_validate(settings)
 
 

--- a/app/domains/notifications/schemas.py
+++ b/app/domains/notifications/schemas.py
@@ -6,6 +6,12 @@ from pydantic import BaseModel, ConfigDict
 from app.domains.notifications.models import NotiKind, NotiStatus
 
 
+class NotificationSettingsUpdate(BaseModel):
+    artist_noti: bool | None = None
+    live_noti: bool | None = None
+    marketing_noti: bool | None = None
+
+
 class NotificationSettingsResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 

--- a/app/domains/notifications/service.py
+++ b/app/domains/notifications/service.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 from typing import cast
 
-from fastapi import WebSocket, WebSocketDisconnect
+from fastapi import HTTPException, WebSocket, WebSocketDisconnect, status
 from tortoise.exceptions import IntegrityError
 from tortoise.expressions import Q
 
@@ -91,6 +91,14 @@ class NotificationService:
         total = await query.count()
         items = await query.order_by("-send_at").offset(offset).limit(limit)
         return list(items), total
+
+    async def delete_user_notification(self, user_id: int, notification_id: int) -> None:
+        deleted = await ConcertNoti.filter(id=notification_id, user_id=user_id).delete()
+        if not deleted:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="알림을 찾을 수 없습니다.",
+            )
 
     async def schedule_session_notifications(
         self, session_id: int, *, session: ConcertSession | None = None

--- a/app/domains/notifications/service.py
+++ b/app/domains/notifications/service.py
@@ -13,6 +13,7 @@ from app.domains.notifications.models import ConcertNoti, NotiKind, NotiStatus, 
 from app.domains.notifications.schemas import (
     NotificationEvent,
     NotificationItem,
+    NotificationSettingsUpdate
 )
 from app.domains.streams.models import ConcertSession, StreamStatus
 from app.domains.users.models import User
@@ -62,6 +63,19 @@ class NotificationService:
             return noti
         except IntegrityError:
             return await UserNoti.get(user_id=user_id)
+
+    async def update_user_settings(
+        self, user_id: int, data: NotificationSettingsUpdate
+    ) -> UserNoti:
+        noti = await self.get_user_settings(user_id)
+        payload = data.model_dump(exclude_unset=True, exclude_none=True)
+        if payload:
+            now = now_kst()
+            await UserNoti.filter(user_id=user_id).update(**payload, updated_at=now)
+            for key, value in payload.items():
+                setattr(noti, key, value)
+            noti.updated_at = now
+        return noti
 
     async def list_user_notifications(
         self,

--- a/app/domains/notifications/service.py
+++ b/app/domains/notifications/service.py
@@ -13,7 +13,7 @@ from app.domains.notifications.models import ConcertNoti, NotiKind, NotiStatus, 
 from app.domains.notifications.schemas import (
     NotificationEvent,
     NotificationItem,
-    NotificationSettingsUpdate
+    NotificationSettingsUpdate,
 )
 from app.domains.streams.models import ConcertSession, StreamStatus
 from app.domains.users.models import User

--- a/tests/notifications/test_router.py
+++ b/tests/notifications/test_router.py
@@ -1,0 +1,70 @@
+import pytest
+from fastapi import status
+from httpx import ASGITransport, AsyncClient
+
+from app.api.deps import get_current_user
+from app.domains.notifications.models import UserNoti
+from app.domains.users.models import ProviderChoice, User
+from app.main import app
+
+
+@pytest.mark.asyncio
+async def test_get_notification_settings_creates_default() -> None:
+    user = await User.create(
+        provider=ProviderChoice.KAKAO,
+        provider_id="kakao_notice_settings",
+        nickname="notice_settings",
+    )
+
+    async def override_get_current_user() -> User:
+        return user
+
+    app.dependency_overrides[get_current_user] = override_get_current_user
+
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            response = await ac.get("/api/v1/notifications/settings")
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["artist_noti"] is True
+        assert data["live_noti"] is True
+        assert data["marketing_noti"] is False
+        assert "updated_at" in data
+
+        assert await UserNoti.filter(user_id=user.id).count() == 1
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_patch_notification_settings_updates_fields() -> None:
+    user = await User.create(
+        provider=ProviderChoice.KAKAO,
+        provider_id="kakao_notice_settings_patch",
+        nickname="notice_settings_patch",
+    )
+
+    async def override_get_current_user() -> User:
+        return user
+
+    app.dependency_overrides[get_current_user] = override_get_current_user
+
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            payload = {"artist_noti": False, "marketing_noti": True}
+            response = await ac.patch("/api/v1/notifications/settings", json=payload)
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["artist_noti"] is False
+        assert data["marketing_noti"] is True
+        assert data["live_noti"] is True
+        assert "updated_at" in data
+
+        saved = await UserNoti.get(user_id=user.id)
+        assert saved.artist_noti is False
+        assert saved.marketing_noti is True
+        assert saved.live_noti is True
+    finally:
+        app.dependency_overrides.clear()

--- a/tests/notifications/test_router.py
+++ b/tests/notifications/test_router.py
@@ -3,7 +3,9 @@ from fastapi import status
 from httpx import ASGITransport, AsyncClient
 
 from app.api.deps import get_current_user
-from app.domains.notifications.models import UserNoti
+from app.core.config import now_kst
+from app.domains.notifications.models import ConcertNoti, NotiKind, NotiStatus, UserNoti
+from app.domains.streams.models import CategoryType, Concert, ConcertSession
 from app.domains.users.models import ProviderChoice, User
 from app.main import app
 
@@ -66,5 +68,41 @@ async def test_patch_notification_settings_updates_fields() -> None:
         assert saved.artist_noti is False
         assert saved.marketing_noti is True
         assert saved.live_noti is True
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_delete_notification_removes_only_user_record() -> None:
+    user = await User.create(
+        provider=ProviderChoice.KAKAO,
+        provider_id="kakao_notice_delete",
+        nickname="notice_delete",
+    )
+    concert = await Concert.create(title="Notice Delete", category=CategoryType.KPOP)
+    session = await ConcertSession.create(
+        concert=concert, session_name="Delete", start_at=now_kst()
+    )
+    noti = await ConcertNoti.create(
+        user=user,
+        session=session,
+        kind=NotiKind.START,
+        title="delete",
+        message="msg",
+        send_at=now_kst(),
+        status=NotiStatus.PENDING,
+    )
+
+    async def override_get_current_user() -> User:
+        return user
+
+    app.dependency_overrides[get_current_user] = override_get_current_user
+
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            response = await ac.delete(f"/api/v1/notifications/{noti.id}")
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        assert await ConcertNoti.filter(id=noti.id).count() == 0
     finally:
         app.dependency_overrides.clear()


### PR DESCRIPTION
## ✅ PR 한줄 요약
- 사용자 알림 설정 수정 + 알림 삭제 기능 추가

## 🔗 관련 이슈
- Jira: NEAR-99

## 🛠️ 변경 내용
- [x] notifications/router.py : 알림 삭제, 사용자 알림 설정 수정 라우터 추가
- [x] notifications/schemas.py : 알림 삭제, 사용자 알림 설정 수정 응답 스키마 추가
- [x] notifications/service.py : 알림 삭제, 사용자 알림 설정 수정 응답 서비스 로직 추가

## 🧪 테스트
- [x] 로컬 테스트 완료 (`uv run pytest -q`)
- [x] ruff/mypy 통과 확인
  - [x] `uv run ruff check .`
  - [x] `uv run ruff format --check .`
  - [x] `uv run mypy .`

## ⚠️ 리뷰 포인트 / 주의사항
- 없음

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했습니다.
- [x] 불필요한 주석/로그를 제거했습니다.
- [x] 문서/설정 변경이 필요하면 반영했습니다.