### PR TITLE
Near 80 user artist follow

### DIFF
--- a/app/domains/artists/schemas.py
+++ b/app/domains/artists/schemas.py
@@ -1,15 +1,24 @@
 from datetime import date
 
-from pydantic import BaseModel, HttpUrl
+from pydantic import BaseModel, ConfigDict, Field, HttpUrl
 
 from app.domains.artists.models import GroupType
 
 
-class ArtistListElement(BaseModel):
-    id: int  # 모델 정의에 따라 string 또는 int 선택
-    name: str
-    profile_image: HttpUrl | str
-    company: str | None
+class ArtistBase(BaseModel):
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
+
+    id: int
+    name: str = Field(
+        ..., alias="stage_name", serialization_alias="name"
+    )  # 필드명: name, DB: stage_name
+    profile_image: HttpUrl | str | None = Field(
+        None, alias="profile_img_url", serialization_alias="profile_image"
+    )
+
+
+class ArtistListElement(ArtistBase):
+    company: str | None = Field(None, alias="agency")
     description: str | None
     follower_count: int
 
@@ -21,14 +30,8 @@ class ArtistListResponse(BaseModel):
     items: list[ArtistListElement]
 
 
-class ArtistDetailResponse(BaseModel):
-    id: int
-    name: str
-    profile_image: HttpUrl | str | None
-    company: str | None
-    description: str | None
-    category: str | None
+class ArtistDetailResponse(ArtistListElement):
+    category: str = Field(..., alias="category_type")
     debut_date: date | None
     member_count: int | None
     group_type: GroupType | None
-    follower_count: int

--- a/app/domains/users/router.py
+++ b/app/domains/users/router.py
@@ -4,7 +4,13 @@ from fastapi import APIRouter, Body, Depends, File, Response, UploadFile, status
 
 from app.api.deps import get_current_user
 from app.domains.users.models import User
-from app.domains.users.schemas import FavoriteArtistListResponse, UserMeResponse, UserMeUpdate
+from app.domains.users.schemas import (
+    FavoriteArtistCreate,
+    FavoriteArtistListResponse,
+    FavoriteArtistResponse,
+    UserMeResponse,
+    UserMeUpdate,
+)
 from app.domains.users.service import user_service
 
 router = APIRouter(prefix="/users", tags=["users"])
@@ -82,3 +88,16 @@ async def get_my_favorite_artists(
     현재 로그인한 유저가 팔로우 중인 아티스트 목록을 반환합니다.
     """
     return await user_service.get_favorite_artists(current_user)
+
+
+@router.post(
+    "/me/favorite-artists",
+    response_model=FavoriteArtistResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="선호 아티스트 추가",
+    description="로그인한 사용자가 특정 아티스트를 팔로우 목록에 추가합니다.",
+)
+async def add_my_favorite_artist(
+    data: FavoriteArtistCreate, current_user: User = Depends(get_current_user)
+) -> FavoriteArtistResponse:
+    return await user_service.add_follow_artist(current_user, data)

--- a/app/domains/users/schemas.py
+++ b/app/domains/users/schemas.py
@@ -3,6 +3,8 @@ from datetime import datetime
 from fastapi import UploadFile
 from pydantic import BaseModel, ConfigDict, Field
 
+from app.domains.artists.models import GroupType
+from app.domains.artists.schemas import ArtistBase
 from app.domains.notifications.models import UserNoti
 from app.domains.streams.models import CategoryType
 from app.domains.users.models import User, UserCatFav
@@ -71,17 +73,34 @@ class UserMeUpdate(BaseModel):
     updated_at: datetime
 
 
-class FavoriteArtistItem(BaseModel):
-    id: int
-    stage_name: str
-    profile_img_url: str | None
-    category: CategoryType
-    group_type: str | None
+class FavoriteArtistItem(ArtistBase):
+    """목록 조회용 (기존 ArtistBase 상속하도록 변경)"""
+
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
+
+    category_type: CategoryType
+    group_type: GroupType | None = None
     member_count: int | None
-    agency: str | None
-    followed_at: datetime  # (alias="follows.created_at")
+    agency: str | None = None
+    created_at: datetime
 
 
 class FavoriteArtistListResponse(BaseModel):
-    total: int
+    total: int = Field(..., description="총 팔로우 수")
     items: list[FavoriteArtistItem]
+
+
+class FavoriteArtistCreate(BaseModel):
+    artist_id: int = Field(..., description="팔로우할 아티스트의 고유 ID")
+
+
+class FavoriteArtistResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    user_id: int = Field(..., description="사용자 ID")
+    artist_id: int = Field(..., description="아티스트 ID")
+    artist_name: str = Field(..., description="아티스트 이름")
+    artist_profile_image: str | None = Field(
+        None, alias="profile_img_url", description="아티스트 프로필 이미지"
+    )
+    added_at: datetime = Field(..., alias="created_at", description="팔로우 추가 일시")

--- a/app/domains/users/service.py
+++ b/app/domains/users/service.py
@@ -7,12 +7,14 @@ from tortoise.transactions import in_transaction
 
 from app.core.config import settings
 from app.core.utils.image_resizer import ImageResizer
-from app.domains.artists.models import Follow
+from app.domains.artists.models import Artist, Follow
 from app.domains.notifications.models import UserNoti
 from app.domains.users.models import User, UserCatFav, UserDeleteLog
 from app.domains.users.schemas import (
+    FavoriteArtistCreate,
     FavoriteArtistItem,
     FavoriteArtistListResponse,
+    FavoriteArtistResponse,
     UserMeResponse,
     UserMeUpdate,
 )
@@ -155,23 +157,45 @@ class UserService:
             await Follow.filter(user=user).select_related("artist").order_by("-created_at")
         )
 
-        items = []
-        for record in follow_records:
-            artist = record.artist
-            items.append(
-                FavoriteArtistItem(
-                    id=artist.id,
-                    stage_name=artist.stage_name,
-                    profile_img_url=artist.profile_img_url,
-                    category=artist.category_type,
-                    group_type=artist.group_type,
-                    member_count=artist.member_count,
-                    agency=artist.agency,
-                    followed_at=record.created_at,
-                )
+        items = [
+            FavoriteArtistItem(
+                id=record.artist.id,
+                name=record.artist.stage_name,
+                profile_img=record.artist.profile_img_url,
+                category_type=record.artist.category_type,
+                group_type=record.artist.group_type,
+                member_count=record.artist.member_count,
+                agency=record.artist.agency,
+                created_at=record.created_at,
             )
+            for record in follow_records
+        ]
 
         return FavoriteArtistListResponse(total=len(items), items=items)
+
+    async def add_follow_artist(
+        self, user: User, data: FavoriteArtistCreate
+    ) -> FavoriteArtistResponse:
+        # 아티스트 존재 여부 확인
+        artist = await Artist.get_or_none(id=data.artist_id)
+        if not artist:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"아티스트(ID: {data.artist_id})를 찾을 수 없습니다.",
+            )
+
+        # 중복 팔로우 체크 및 생성 (get_or_create 보다 명시적인 에러 처리를 위해 분리)
+        follow, created = await Follow.get_or_create(user=user, artist=artist)
+        if not created:
+            raise HTTPException(status_code=409, detail="이미 추가된 아티스트입니다.")
+
+        return FavoriteArtistResponse(
+            user_id=user.id,
+            artist_id=artist.id,
+            artist_name=artist.stage_name,  # Artist 모델의 stage_name 사용
+            profile_img_url=artist.profile_img_url,  # alias 설정에 따라 매핑
+            created_at=follow.created_at,  # Follow 모델의 생성일
+        )
 
 
 user_service: UserService = UserService()

--- a/tests/domains/artists/test_artist_router.py
+++ b/tests/domains/artists/test_artist_router.py
@@ -23,7 +23,12 @@ class TestArtistRouter:
     async def test_get_artist_detail_router(self, client: AsyncClient, initialize_tests):
         """GET /artists/{artist_id} 라우터 엔드포인트를 테스트합니다."""
         # 데이터 준비
-        await Artist.create(id=2, stage_name="Detail Router", agency="Router Agency")
+        await Artist.create(
+            id=2,
+            stage_name="Detail Router",
+            agency="Router Agency",
+            category_type=CategoryType.KPOP,
+        )
 
         # API 호출
         response = await client.get("/api/v1/artists/2")

--- a/tests/domains/artists/test_artist_service.py
+++ b/tests/domains/artists/test_artist_service.py
@@ -89,7 +89,11 @@ class TestArtistService:
     async def test_get_artist_detail_success(self, initialize_tests):
         """아티스트 상세 조회가 정상 작동하는지 테스트합니다."""
         await Artist.create(
-            id=501, stage_name="Detail Artist", agency="Test Agency", description="Test Description"
+            id=501,
+            stage_name="Detail Artist",
+            agency="Test Agency",
+            description="Test Description",
+            category_type=CategoryType.KPOP,
         )
 
         response = await artist_service.get_artist_detail(artist_id=501)


### PR DESCRIPTION
✅ PR 한줄 요약
* 사용자의 선호 아티스트 팔로우(추가) 기능을 구현하고 도메인 간 스키마 중복을 제거하기 위해 리팩토링을 진행했습니다. 

🔗 관련 이슈
* Jira: NEAR-80
* GitHub: # 

🛠️ 변경 내용
* [x] 선호 아티스트 추가 엔드포인트 구현: POST /users/me/favorite-artists 엔드포인트를 추가하여 사용자가 특정 아티스트를 팔로우할 수 있도록 구현했습니다.
* [x] 스키마 상속 구조 도입: ArtistBase를 상속받아 FavoriteArtistItem을 정의함으로써 도메인 간 중복 코드를 제거하고 필드 일관성을 확보했습니다.
* [x] 응답 데이터 최적화: alias 설정을 통해 모델의 stage_name, profile_img_url 등을 API 규격에 맞는 name, profile_image로 노출되도록 개선했습니다. 

🧪 테스트
* [x] 로컬 테스트 완료 (uv run pytest -q)
* [x] ruff/mypy 통과 확인
    * [x] uv run ruff check .
    * [x] uv run ruff format --check .
    * [x] uv run mypy . 

⚠️ 리뷰 포인트 / 주의사항
*

✅ 체크리스트
* [x] 커밋 메시지 컨벤션을 준수했습니다.
* [x] 불필요한 주석/로그를 제거했습니다.
* [x] 문서/설정 변경이 필요하면 반영했습니다.