### PR TITLE
Near 103 concert images upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,7 @@ jobs:
       AWS_REGION: ap-northeast-2
       IVS_PLAYBACK_PRIVATE_KEY_B64: ${{ secrets.IVS_PLAYBACK_PRIVATE_KEY_B64 }}
       S3_RECORDING_BUCKET: my-concert-ivs-recordings
+      IMAGES_BUCKET: ${{ secrets.IMAGES_BUCKET }}
 
       ADMIN_SECRET_KEY: ${{ secrets.ADMIN_SECRET_KEY }}
       ADMIN_USERNAME: admin

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -64,6 +64,7 @@ class Settings(BaseSettings):
     AWS_REGION: str = "ap-northeast-2"
     IVS_PLAYBACK_PRIVATE_KEY_B64: str = Field(..., validation_alias="IVS_PLAYBACK_PRIVATE_KEY_B64")
     S3_RECORDING_BUCKET: str
+    IMAGES_BUCKET: str
 
     # social_login
     KAKAO_REST_API_KEY: str

--- a/app/core/utils/image_resizer.py
+++ b/app/core/utils/image_resizer.py
@@ -74,7 +74,7 @@ class ImageResizer:
     async def delete_all_by_id_path(self, image_url: str | None) -> None:
         """
         URL에서 폴더 경로를 추출하여 해당 폴더 내의 모든 파일을 삭제합니다.
-        보안을 위해 유저 프로필 경로 패턴(users/{id}/profile)만 허용합니다.
+        보안을 위해 지정한 경로 패턴(users/{id}/profile 등)만 허용합니다.
         """
         if not image_url:
             return
@@ -84,9 +84,13 @@ class ImageResizer:
             full_path = parsed_url.path.lstrip("/")
             folder_prefix = os.path.dirname(full_path)  # ex: "users/1/profile"
 
-            # users/{숫자}/profile 패턴인지 확인
-            profile_path_pattern = r"^users/\d+/profile$"
-            if not re.match(profile_path_pattern, folder_prefix):
+            # users/{숫자}/profile 등의 패턴인지 확인
+            allowed_patterns = [
+                r"^users/\d+/profile$",
+                r"^artists/\d+/profile$",
+                r"^concerts/\d+/thumbnail$",
+            ]
+            if not any(re.match(pattern, folder_prefix) for pattern in allowed_patterns):
                 logger.warning(f"S3 삭제 거부: 허용되지 않은 경로 접근 ({folder_prefix})")
                 return
 

--- a/app/core/utils/image_resizer.py
+++ b/app/core/utils/image_resizer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import io
+import logging
 import os
 import re
 from typing import Any
@@ -9,7 +10,9 @@ from urllib.parse import urlparse
 from fastapi import HTTPException, status
 from PIL import Image, ImageOps
 
-from app.core.utils.s3_client import S3Client
+from app.integrations.s3_client import S3Client
+
+logger = logging.getLogger(__name__)
 
 
 class ImageResizer:
@@ -29,9 +32,11 @@ class ImageResizer:
             source.load()
         except Exception as exc:
             raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail="이미지 처리에 실패했습니다.",
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="유효한 이미지 파일이 아닙니다.",
             ) from exc
+
+        base_prefix = path_prefix.rstrip("/")
 
         for size in sizes:
             try:
@@ -46,20 +51,24 @@ class ImageResizer:
                 buffer.name = f"image_{size}.png"
                 resized.save(buffer, format="PNG")
                 buffer.seek(0)
+
+                key = f"{base_prefix}/image_{size}.png"
+
+                # 비동기 업로드 호출
+                await self.s3_client.upload_with_key(
+                    buffer,
+                    key=key,
+                    extra_args={"ContentType": "image/png"},
+                )
+
+                urls[str(size)] = self.s3_client.build_url(key)
+
             except Exception as exc:
                 raise HTTPException(
                     status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                    detail="이미지 리사이징에 실패했습니다.",
+                    detail="이미지 리사이징 또는 업로드에 실패했습니다.",
                 ) from exc
 
-            base_prefix = path_prefix.rstrip("/")
-            # 비동기 업로드 호출
-            key = await self.s3_client.upload_with_key(
-                buffer,
-                key=f"{base_prefix}/profile{size}.png",
-                extra_args={"ContentType": "image/png"},
-            )
-            urls[str(size)] = self.s3_client.build_url(key)
         return urls
 
     async def delete_all_by_id_path(self, image_url: str | None) -> None:
@@ -78,12 +87,11 @@ class ImageResizer:
             # users/{숫자}/profile 패턴인지 확인
             profile_path_pattern = r"^users/\d+/profile$"
             if not re.match(profile_path_pattern, folder_prefix):
-                print(f"S3 삭제 거부: 허용되지 않은 경로 접근 ({folder_prefix})")
+                logger.warning(f"S3 삭제 거부: 허용되지 않은 경로 접근 ({folder_prefix})")
                 return
 
-            if folder_prefix:
-                await self.s3_client.delete_prefix(prefix=folder_prefix)
-                print(f"S3 이미지 폴더 삭제 완료: {folder_prefix}")
+            await self.s3_client.delete_prefix(prefix=folder_prefix)
+            logger.info(f"S3 이미지 폴더 삭제 완료: {folder_prefix}")
 
         except Exception as e:
-            print(f"S3 삭제 도중 에러 발생: {e}")
+            logger.error(f"S3 삭제 도중 에러 발생: {e}", exc_info=True)

--- a/app/core/utils/s3_client.py
+++ b/app/core/utils/s3_client.py
@@ -101,15 +101,9 @@ class S3Client:
         if not key:
             return ""
 
-        custom_domain = getattr(settings, "AWS_S3_CUSTOM_DOMAIN", None)
-
-        if custom_domain:
-            domain = custom_domain
-        else:
-            region = settings.AWS_REGION
-            domain = f"{self.bucket_name}.s3.{region}.amazonaws.com"
-
-        return f"https://{domain.rstrip('/')}/{key.lstrip('/')}"
+        return (
+            f"https://{self.bucket_name}.s3.{settings.AWS_REGION}.amazonaws.com/{key.lstrip('/')}"
+        )
 
     async def generate_presigned_url(self, key: str, expires_in: int = 3600) -> str:
         try:

--- a/app/core/utils/s3_client.py
+++ b/app/core/utils/s3_client.py
@@ -15,7 +15,7 @@ ALLOWED_IMAGE_EXTENSIONS = {"jpg", "jpeg", "png", "webp"}
 class S3Client:
     def __init__(self) -> None:
         self.session = aioboto3.Session()
-        self.bucket_name = settings.S3_RECORDING_BUCKET
+        self.bucket_name = settings.IMAGES_BUCKET
         self.aws_config = {
             "aws_access_key_id": settings.AWS_ACCESS_KEY_ID,
             "aws_secret_access_key": settings.AWS_SECRET_ACCESS_KEY,

--- a/app/core/utils/s3_client.py
+++ b/app/core/utils/s3_client.py
@@ -9,6 +9,8 @@ from app.core.config import settings
 
 logger = logging.getLogger(__name__)
 
+ALLOWED_IMAGE_EXTENSIONS = {"jpg", "jpeg", "png", "webp"}
+
 
 class S3Client:
     def __init__(self) -> None:
@@ -24,7 +26,9 @@ class S3Client:
         self, file: Any, path_prefix: str = "", extra_args: dict[str, Any] | None = None
     ) -> str:
         original_name = getattr(file, "name", "unknown_file")
-        ext = original_name.split(".")[-1] if "." in original_name else "bin"
+        ext = original_name.split(".")[-1].lower() if "." in original_name else "bin"
+        if ext not in ALLOWED_IMAGE_EXTENSIONS:
+            ext = "bin"
 
         file_name = f"{uuid.uuid4()}.{ext}"
 

--- a/app/domains/streams/admin/router.py
+++ b/app/domains/streams/admin/router.py
@@ -1,4 +1,15 @@
-from fastapi import APIRouter, Body, Depends, Path, Query, Request, Response, status
+from fastapi import (
+    APIRouter,
+    Body,
+    Depends,
+    File,
+    Path,
+    Query,
+    Request,
+    Response,
+    UploadFile,
+    status,
+)
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 
@@ -34,6 +45,24 @@ async def create_concert(
     service: StreamAdminService = Depends(streams_deps.get_stream_admin_service),
 ) -> Concert:
     return await service.create_concert(data, current_admin)
+
+
+@router.patch(
+    "/concerts/{concert_id}/thumbnail",
+    response_model=ConcertResponse,
+    summary="콘서트 썸네일 이미지 생성 및 수정",
+    description="콘서트 썸네일 이미지를 업로드 또는 수정합니다.",
+)
+async def update_concert_thumbnail(
+    current_admin: User = Depends(get_admin_user),
+    concert_id: int = Path(..., description="콘서트 ID"),
+    thumbnail_file: UploadFile = File(..., description="썸네일 이미지 파일"),
+    service: StreamAdminService = Depends(streams_deps.get_stream_admin_service),
+) -> Concert:
+    # 인증된 current_admin 객체를 서비스로 직접 전달
+    return await service.update_concert_thumbnail(
+        concert_id=concert_id, file=thumbnail_file, user=current_admin
+    )
 
 
 @router.post(

--- a/app/domains/streams/admin/schemas.py
+++ b/app/domains/streams/admin/schemas.py
@@ -112,6 +112,7 @@ class ConcertResponse(BaseModel):
     title: str
     category: CategoryType
     description: str | None = None
+    thumbnail_url: str | None = Field(None)
     created_at: datetime
 
 

--- a/app/domains/streams/admin/service.py
+++ b/app/domains/streams/admin/service.py
@@ -1,10 +1,11 @@
 from typing import Literal, cast
 
 from botocore.exceptions import ClientError
-from fastapi import HTTPException
+from fastapi import HTTPException, UploadFile
 from mypy_boto3_ivs.type_defs import GetStreamResponseTypeDef
 
 from app.core.pagination import paginate_cursor
+from app.core.utils.image_resizer import ImageResizer
 from app.domains.artists.models import Artist
 from app.domains.streams.admin.schemas import (
     ConcertCreateRequest,
@@ -34,6 +35,7 @@ class StreamAdminService:
     def __init__(self, ivs_client: IVSClient, playback_provider: IVSPlaybackProvider):
         self.ivs_client = ivs_client
         self.playback_provider = playback_provider
+        self.image_resizer = ImageResizer()
 
     async def create_concert(self, data: ConcertCreateRequest, user: User) -> Concert:
         """
@@ -41,6 +43,38 @@ class StreamAdminService:
         """
         StreamPermission.must_be_admin(user)
         return await Concert.create(**data.model_dump())
+
+    async def update_concert_thumbnail(
+        self, concert_id: int, file: UploadFile, user: User
+    ) -> Concert:
+        """
+        [Admin] 콘서트 썸네일 생성 및 수정
+        """
+        StreamPermission.must_be_admin(user)
+
+        # 콘서트 있는지 확인
+        concert = await Concert.get_or_none(id=concert_id)
+        if not concert:
+            raise HTTPException(status_code=404, detail="콘서트를 찾을 수 없습니다.")
+
+        # 기존 이미지가 있다면 S3 폴더 삭제
+        if concert.thumbnail_url:
+            await self.image_resizer.delete_all_by_id_path(concert.thumbnail_url)
+
+        # 새로운 이미지 리사이징 업로드
+        path_prefix = f"concerts/{concert.id}/thumbnail"
+        sizes = (300, 640, 1280)
+
+        urls = await self.image_resizer.upload_square_resizes(
+            image_file=file.file, sizes=sizes, path_prefix=path_prefix
+        )
+
+        # DB 업데이트
+        img_url = urls.get("640")
+        concert.thumbnail_url = img_url if img_url else ""
+        await concert.save()
+
+        return concert
 
     async def create_session_with_infrastructure(
         self, concert_id: int, data: SessionCreateRequest, user: User

--- a/app/integrations/s3_client.py
+++ b/app/integrations/s3_client.py
@@ -1,3 +1,19 @@
+"""
+ImageStorage 전용 S3 클라이언트 (IVS 녹화는 cfn에서 자동 설정함)
+
+- IVS S3 버킷과는 분리된 버킷을 사용 -> 따라서 bucket_name은 settings.IMAGES_BUCKET으로 고정함
+- Image 외 파일 업로드 금지
+- path_prefix는 아래와 같이 고정
+    1) 유저 프로필 이미지
+        path_prefix=f"users/{user_id}/profile/"
+
+    2) 아티스트 프로필 이미지
+        path_prefix=f"artists/{artist_id}/profile/"
+
+    3) 콘서트 썸네일 이미지
+        path_prefix=f"concerts/{concert_id}/thumbnail/"
+"""
+
 import logging
 import uuid
 from typing import Any, cast

--- a/tests/core/utils/image_resizer.py
+++ b/tests/core/utils/image_resizer.py
@@ -1,0 +1,176 @@
+import io
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from botocore.exceptions import ClientError
+from fastapi import HTTPException
+from PIL import Image
+
+from app.core.utils.image_resizer import ImageResizer
+from app.integrations.s3_client import S3Client
+
+
+@pytest.fixture
+def mock_s3_session():
+    """aioboto3 Session 모킹 헬퍼"""
+    with patch("app.integrations.s3_client.aioboto3.Session") as mock_session_class:
+        mock_session = MagicMock()
+        mock_session_class.return_value = mock_session
+        yield mock_session
+
+
+def setup_s3_method(mock_session, method_name, side_effect=None, return_value=None):
+    """S3 클라이언트 메서드 동작 설정"""
+    mock_s3 = MagicMock()
+    mock_method = AsyncMock(side_effect=side_effect, return_value=return_value)
+    setattr(mock_s3, method_name, mock_method)
+
+    # Context Manager 설정 (__aenter__, __aexit__)
+    mock_client_cm = MagicMock()
+    mock_client_cm.__aenter__ = AsyncMock(return_value=mock_s3)
+    mock_client_cm.__aexit__ = AsyncMock(return_value=None)
+
+    mock_session.client.return_value = mock_client_cm
+    return mock_s3
+
+
+@pytest.mark.asyncio
+async def test_s3_upload_client_error(mock_s3_session):
+    """S3Client.upload: ClientError 발생 시 raise 확인"""
+    setup_s3_method(
+        mock_s3_session,
+        "upload_fileobj",
+        side_effect=ClientError({"Error": {"Code": "403"}}, "upload"),
+    )
+
+    client = S3Client()
+    file = MagicMock(spec=io.BytesIO)
+    file.name = "test.jpg"
+
+    with pytest.raises(ClientError):
+        await client.upload(file)
+
+
+@pytest.mark.asyncio
+async def test_s3_upload_with_key_seek(mock_s3_session):
+    """S3Client.upload_with_key: 데이터가 비어있을 때 seek(0) 로직 확인"""
+    file_obj = MagicMock()
+    # 첫 read는 빈 값, 두 번째는 데이터 반환
+    file_obj.read.side_effect = [b"", b"data"]
+    file_obj.seek.return_value = 0
+
+    setup_s3_method(mock_s3_session, "put_object", return_value={})
+
+    client = S3Client()
+    await client.upload_with_key(file_obj, "key")
+    assert file_obj.seek.called
+
+
+@pytest.mark.asyncio
+async def test_s3_delete_object_warning(mock_s3_session):
+    """S3Client.delete_object: ClientError 발생 시 raise하지 않고 종료"""
+    setup_s3_method(
+        mock_s3_session,
+        "delete_object",
+        side_effect=ClientError({"Error": {"Code": "404"}}, "delete"),
+    )
+
+    client = S3Client()
+    await client.delete_object("missing_key")  # 에러 없이 통과해야 함
+
+
+@pytest.mark.asyncio
+async def test_s3_delete_prefix_no_contents(mock_s3_session):
+    """S3Client.delete_prefix: 삭제할 객체가 없을 때"""
+    mock_s3 = setup_s3_method(mock_s3_session, "list_objects_v2", return_value={})
+    mock_s3.delete_objects = AsyncMock()
+
+    client = S3Client()
+    await client.delete_prefix("empty/")
+    mock_s3.delete_objects.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_s3_presigned_url_error(mock_s3_session):
+    """S3Client.generate_presigned_url: 에러 발생 시 문자열 반환"""
+    setup_s3_method(
+        mock_s3_session,
+        "generate_presigned_url",
+        side_effect=ClientError({"Error": {"Code": "500"}}, "presign"),
+    )
+
+    client = S3Client()
+    result = await client.generate_presigned_url("key")
+    assert "An error occurred" in result
+
+
+def test_s3_build_url_empty():
+    """S3Client.build_url: 빈 키 입력 시 빈 문자열 반환"""
+    assert S3Client().build_url("") == ""
+
+
+@pytest.fixture
+def mock_internal_s3():
+    """ImageResizer에 주입할 모킹된 S3Client"""
+    client = MagicMock(spec=S3Client)
+    client.upload_with_key = AsyncMock()
+    client.delete_prefix = AsyncMock()
+    client.build_url.side_effect = lambda k: f"https://s3.com/{k}"
+    return client
+
+
+@pytest.fixture
+def valid_img():
+    img = Image.new("RGB", (10, 10), color="red")
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    buf.seek(0)
+    buf.name = "test.png"
+    return buf
+
+
+@pytest.mark.asyncio
+async def test_resizer_init():
+    """ImageResizer.__init__: S3Client 자동 생성 확인"""
+    with patch("app.core.utils.image_resizer.S3Client") as mock_cls:
+        resizer = ImageResizer()
+        assert resizer.s3_client is not None
+        mock_cls.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_resizer_upload_success(mock_internal_s3, valid_img):
+    resizer = ImageResizer(s3_client=mock_internal_s3)
+    result = await resizer.upload_square_resizes(image_file=valid_img, sizes=(50,), path_prefix="p")
+    assert "50" in result
+    mock_internal_s3.upload_with_key.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_resizer_upload_loop_exception(mock_internal_s3, valid_img):
+    """ImageResizer: 루프 내부 에러 발생 시 500 에러"""
+    resizer = ImageResizer(s3_client=mock_internal_s3)
+    mock_internal_s3.upload_with_key.side_effect = Exception("Crash")
+
+    with pytest.raises(HTTPException) as exc:
+        await resizer.upload_square_resizes(image_file=valid_img, sizes=(50,), path_prefix="p")
+    assert exc.value.status_code == 500
+
+
+@pytest.mark.asyncio
+async def test_resizer_delete_pattern_mismatch(mock_internal_s3):
+    """ImageResizer: 잘못된 경로 패턴 차단"""
+    resizer = ImageResizer(s3_client=mock_internal_s3)
+    await resizer.delete_all_by_id_path("https://s3.com/invalid/path/img.png")
+    mock_internal_s3.delete_prefix.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_resizer_delete_exception_handling(mock_internal_s3):
+    """ImageResizer: 삭제 중 예외 발생 시 로깅 후 무시"""
+    resizer = ImageResizer(s3_client=mock_internal_s3)
+    mock_internal_s3.delete_prefix.side_effect = Exception("S3 error")
+
+    # 에러가 밖으로 나오지 않아야 함
+    await resizer.delete_all_by_id_path("https://s3.com/users/1/profile/img.png")
+    assert mock_internal_s3.delete_prefix.called

--- a/tests/integrations/test_s3_client.py
+++ b/tests/integrations/test_s3_client.py
@@ -1,0 +1,111 @@
+import io
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from botocore.exceptions import ClientError
+
+from app.integrations.s3_client import S3Client
+
+
+def setup_s3_mock(method_name, side_effect=None, return_value=None):
+    mock_s3 = MagicMock()
+    mock_method = AsyncMock(side_effect=side_effect, return_value=return_value)
+    setattr(mock_s3, method_name, mock_method)
+
+    # generate_presigned_url은 일반 비동기 메서드처럼 동작하도록 별도 설정
+    if method_name == "generate_presigned_url":
+        mock_s3.generate_presigned_url = AsyncMock(
+            side_effect=side_effect, return_value=return_value
+        )
+
+    mock_client_cm = MagicMock()
+    mock_client_cm.__aenter__ = AsyncMock(return_value=mock_s3)
+    mock_client_cm.__aexit__ = AsyncMock(return_value=None)
+
+    mock_session = MagicMock()
+    mock_session.client.return_value = mock_client_cm
+    return mock_session, mock_s3
+
+
+@pytest.mark.asyncio
+async def test_upload_client_error_coverage_47():
+    """upload 메서드 ClientError 발생 테스트"""
+    mock_session, _ = setup_s3_mock(
+        "upload_fileobj",
+        side_effect=ClientError({"Error": {"Code": "403", "Message": "Forbidden"}}, "Upload"),
+    )
+
+    with patch("app.integrations.s3_client.aioboto3.Session", return_value=mock_session):
+        s3_client = S3Client()
+        file = MagicMock(spec=io.BytesIO)
+        file.name = "test.png"
+        with pytest.raises(ClientError):
+            await s3_client.upload(file)
+
+
+@pytest.mark.asyncio
+async def test_upload_with_key_seek_coverage_85_86():
+    """file_obj.read()가 비어있을 때 seek(0) 동작 테스트"""
+    file_obj = MagicMock()
+    # 첫 호출 시 b"", 두 번째 호출 시 데이터 반환하도록 설정
+    file_obj.read.side_effect = [b"", b"recovered content"]
+    file_obj.seek.return_value = 0
+
+    mock_session, mock_s3 = setup_s3_mock("put_object", return_value={})
+
+    with patch("app.integrations.s3_client.aioboto3.Session", return_value=mock_session):
+        s3_client = S3Client()
+        await s3_client.upload_with_key(file_obj, "test_key")
+
+        assert file_obj.seek.called
+        assert mock_s3.put_object.call_args.kwargs["Body"] == b"recovered content"
+
+
+@pytest.mark.asyncio
+async def test_delete_object_client_error_coverage_105_109():
+    """delete_object ClientError 발생 시 warning 로그 확인"""
+    mock_session, _ = setup_s3_mock(
+        "delete_object",
+        side_effect=ClientError({"Error": {"Code": "404", "Message": "Not Found"}}, "Delete"),
+    )
+
+    with patch("app.integrations.s3_client.aioboto3.Session", return_value=mock_session):
+        s3_client = S3Client()
+        # 예외가 raise되지 않고 warning 로그만 남아야 함
+        await s3_client.delete_object("missing_key")
+
+
+@pytest.mark.asyncio
+async def test_delete_prefix_no_contents_coverage_121_124():
+    """삭제할 객체가 없을 때(Contents 미포함) 조기 종료 테스트"""
+    # Contents 키가 없는 딕셔너리 반환
+    mock_session, mock_s3 = setup_s3_mock("list_objects_v2", return_value={})
+    mock_s3.delete_objects = AsyncMock()
+
+    with patch("app.integrations.s3_client.aioboto3.Session", return_value=mock_session):
+        s3_client = S3Client()
+        await s3_client.delete_prefix("empty/prefix/")
+
+        mock_s3.list_objects_v2.assert_awaited_once()
+        mock_s3.delete_objects.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_generate_presigned_url_error_coverage_139():
+    """presigned_url 생성 실패 시 에러 스트링 반환 테스트"""
+    mock_session, _ = setup_s3_mock(
+        "generate_presigned_url",
+        side_effect=ClientError({"Error": {"Code": "500", "Message": "InternalError"}}, "Presign"),
+    )
+
+    with patch("app.integrations.s3_client.aioboto3.Session", return_value=mock_session):
+        s3_client = S3Client()
+        result = await s3_client.generate_presigned_url("test_key")
+        assert "An error occurred (500)" in result
+
+
+def test_build_url_empty_key():
+    """build_url의 key가 없을 때의 분기 테스트"""
+    s3_client = S3Client()
+    assert s3_client.build_url("") == ""
+    assert "https://" in s3_client.build_url("some_key")

--- a/tests/streams/admin/test_router.py
+++ b/tests/streams/admin/test_router.py
@@ -5,7 +5,7 @@ import pytest
 from httpx import ASGITransport, AsyncClient
 
 from app.domains.streams.deps import get_admin_user
-from app.domains.streams.models import AccessLevel, ChannelType, LatencyMode, StreamStatus
+from app.domains.streams.models import AccessLevel, ChannelType, Concert, LatencyMode, StreamStatus
 from app.main import app
 
 
@@ -55,11 +55,12 @@ class TestStreamRouter:
                 ) as mock_create_session,
             ):
                 # concert mock
-                mock_concert = MagicMock()
+                mock_concert = MagicMock(spec=Concert)
                 mock_concert.id = 1
                 mock_concert.title = "Test Concert"
                 mock_concert.description = "Test Description"
                 mock_concert.category = "K-POP"
+                mock_concert.thumbnail_url = None
                 mock_concert.created_at = datetime.now()
                 mock_create_concert.return_value = mock_concert
 

--- a/tests/streams/admin/test_thumbnail.py
+++ b/tests/streams/admin/test_thumbnail.py
@@ -1,0 +1,202 @@
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.domains.streams.deps import get_admin_user
+from app.domains.streams.models import AccessLevel, StreamStatus
+from app.main import app
+
+
+# Tortoise-ORM 쿼리 체이닝 흉내
+class AsyncQueryMock:
+    def __init__(self, return_value):
+        self.return_value = return_value
+
+    def prefetch_related(self, *args, **kwargs):
+        return self
+
+    def select_for_update(self, *args, **kwargs):
+        return self
+
+    def filter(self, *args, **kwargs):
+        return self
+
+    def first(self):
+        return self
+
+    def __await__(self):
+        async def _internal():
+            return self.return_value
+
+        return _internal().__await__()
+
+
+@pytest.mark.asyncio
+class TestStreamAdminCoverage:
+    @pytest.fixture
+    async def client(self):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            yield ac
+
+    @pytest.fixture
+    def mock_admin_user(self):
+        user = MagicMock()
+        user.id = 1
+        user.is_admin = True
+        user.is_superuser = True
+        return user
+
+    @pytest.fixture
+    def mock_session_data(self):
+        session = MagicMock()
+        session.id = 1
+        session.session_name = "테스트 세션"
+        session.access_level = AccessLevel.PUBLIC
+        session.status = StreamStatus.READY
+        session.start_at = datetime.now(UTC)  # None 대신 실제 객체
+
+        channel = MagicMock()
+        channel.channel_arn = "arn:aws:ivs:test"
+        channel.ingest_endpoint = "rtmps://ingest.com"
+        channel.playback_url = "https://playback.com"
+        channel.latency_mode = MagicMock(value="LOW")
+        channel.type = MagicMock(value="STANDARD")
+        channel.get_stream_key.return_value = "key"
+        channel.is_private = False
+
+        session.stream_channel = channel
+        concert = MagicMock()
+        concert.id = 99
+        concert.title = "콘서트"
+        concert.category = "K-POP"
+        concert.description = "설명"
+        concert.thumbnail_url = "old.png"
+        concert.thumbnailUrl = "old.png"
+
+        session.concert = concert
+        session.save = AsyncMock()
+        session.delete = AsyncMock()
+        return session
+
+    # 1. [Service 53-77] 썸네일 업로드 로직 격파
+    async def test_update_concert_thumbnail_full_logic(
+        self, client, mock_admin_user, mock_session_data
+    ):
+        app.dependency_overrides[get_admin_user] = lambda: mock_admin_user
+        mock_concert = mock_session_data.concert
+        mock_concert.save = AsyncMock()
+
+        with (
+            patch(
+                "app.domains.streams.models.Concert.get_or_none",
+                new_callable=AsyncMock,
+                return_value=mock_concert,
+            ),
+            patch(
+                "app.core.utils.image_resizer.ImageResizer.delete_all_by_id_path",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "app.core.utils.image_resizer.ImageResizer.upload_square_resizes",
+                new_callable=AsyncMock,
+                return_value={"640": "new.png"},
+            ),
+        ):
+            files = {"thumbnail_file": ("test.jpg", b"data", "image/jpeg")}
+            res = await client.patch("/api/v1/admin/streams/concerts/99/thumbnail", files=files)
+            assert res.status_code == 200
+            assert mock_concert.thumbnail_url == "new.png"
+
+    # 2. [Service 163, 216, 239] 삭제/중단 AWS 예외 로그 처리 격파
+    async def test_aws_exception_warning_logs(self, client, mock_admin_user, mock_session_data):
+        app.dependency_overrides[get_admin_user] = lambda: mock_admin_user
+        query_mock = AsyncQueryMock(mock_session_data)
+
+        # 삭제 시 AWS 에러 발생 (Service 163)
+        with (
+            patch("app.domains.streams.models.ConcertSession.get_or_none", return_value=query_mock),
+            patch(
+                "app.integrations.aws_ivs.IVSClient.delete_channel",
+                side_effect=Exception("AWS Error"),
+            ),
+        ):
+            res = await client.delete("/api/v1/admin/streams/sessions/1")
+            assert res.status_code == 204
+
+        # 중단 시 AWS 에러 발생 (Service 216)
+        with (
+            patch("app.domains.streams.models.ConcertSession.get", return_value=query_mock),
+            patch(
+                "app.integrations.aws_ivs.IVSClient.stop_stream", side_effect=Exception("AWS Error")
+            ),
+        ):
+            res = await client.post("/api/v1/admin/streams/sessions/1/stop")
+            assert res.status_code == 200
+
+    # 3. [Service 374-378] 아티스트 매핑 업데이트 및 Pydantic 에러 해결
+    async def test_update_session_artist_mapping_and_pydantic(
+        self, client, mock_admin_user, mock_session_data
+    ):
+        app.dependency_overrides[get_admin_user] = lambda: mock_admin_user
+        query_mock = AsyncQueryMock(mock_session_data)
+
+        from app.domains.streams.admin.schemas import IVSChannelSummary, SessionResponse
+
+        mock_response = SessionResponse(
+            id=1,
+            session_name="세션",
+            access_level=AccessLevel.PUBLIC,
+            status=StreamStatus.READY,
+            start_at=datetime.now(UTC),  # 👈 여기서 datetime 객체를 줌으로써 ValidationError 해결
+            channel=IVSChannelSummary(
+                arn="arn",
+                ingest_endpoint="ep",
+                playback_url="url",
+                latency_mode="LOW",
+                type="STANDARD",
+            ),
+        )
+
+        with (
+            patch("app.domains.streams.models.ConcertSession.filter", return_value=query_mock),
+            patch(
+                "app.domains.artists.models.Artist.filter",
+                new_callable=AsyncMock,
+                return_value=[MagicMock(id=7)],
+            ),
+            patch("app.domains.streams.models.ConcertArtist.filter") as mock_ca_filter,
+            patch("app.domains.streams.models.ConcertArtist.create", new_callable=AsyncMock),
+            patch(
+                "app.domains.streams.admin.service.StreamAdminService.get_session_admin_detail",
+                new_callable=AsyncMock,
+                return_value=mock_response,
+            ),
+        ):
+            mock_ca_filter.return_value.delete = AsyncMock()
+            # artist_ids를 실어서 374-378 라인을 타게 함
+            res = await client.patch("/api/v1/admin/streams/sessions/1", json={"artist_ids": [7]})
+            assert res.status_code == 200
+
+    # 4. [Service 411] 라이브 메트릭 계산
+    async def test_get_session_ingest_metrics_coverage(
+        self, client, mock_admin_user, mock_session_data
+    ):
+        app.dependency_overrides[get_admin_user] = lambda: mock_admin_user
+        query_mock = AsyncQueryMock(mock_session_data)
+        mock_health = {
+            "stream": {
+                "health": "HEALTHY",
+                "viewerCount": 5,
+                "state": "LIVE",
+                "startTime": datetime.now(UTC),
+            }
+        }
+
+        with (
+            patch("app.domains.streams.models.ConcertSession.get", return_value=query_mock),
+            patch("app.integrations.aws_ivs.IVSClient.get_stream_health", return_value=mock_health),
+        ):
+            res = await client.get("/api/v1/admin/streams/sessions/1/ingest")
+            assert res.status_code == 200

--- a/tests/users/test_service.py
+++ b/tests/users/test_service.py
@@ -6,13 +6,13 @@ import pytest
 from botocore.exceptions import ClientError
 from fastapi import HTTPException
 
-from app.core.utils.s3_client import S3Client
 from app.domains.artists.models import Artist
 from app.domains.notifications.models import UserNoti
 from app.domains.streams.models import CategoryType
 from app.domains.users.models import GenderChoices, ProviderChoice, User, UserCatFav, UserDeleteLog
 from app.domains.users.schemas import NotiSettings, UserMeUpdate
 from app.domains.users.service import user_service
+from app.integrations.s3_client import S3Client
 
 
 @pytest.mark.asyncio
@@ -95,9 +95,9 @@ async def test_update_profile_image_coverage(initialize_tests):
 
     with (
         patch(
-            "app.core.utils.s3_client.S3Client.upload_with_key", new_callable=AsyncMock
+            "app.integrations.s3_client.S3Client.upload_with_key", new_callable=AsyncMock
         ) as mock_s3_upload,
-        patch("app.core.utils.s3_client.S3Client.build_url") as mock_build_url,
+        patch("app.integrations.s3_client.S3Client.build_url") as mock_build_url,
     ):
         mock_s3_upload.return_value = "users/1/profile/profile200.png"
         mock_build_url.return_value = "http://s3.url/200.png"


### PR DESCRIPTION
## ✅ PR 한줄 요약
- s3 버킷 이미지 업로드용 분리
- s3 client 함수 수정 및 integrations로 이동
- image-resizer 전역 사용을 위해 코드 수정(기존 profile용)
- concert thumbnail image 업로드(삭제 후 수정 포함) 라우터 추가

## 🔗 관련 이슈
- Jira: NEAR-103

## 🛠️ 변경 내용
- [x] 위와 동일

## 🧪 테스트
- [x] 로컬 테스트 완료 (`uv run pytest -q`)
- [x] ruff/mypy 통과 확인
  - [x] `uv run ruff check .`
  - [x] `uv run ruff format --check .`
  - [x] `uv run mypy .`

## ⚠️ 리뷰 포인트 / 주의사항
- env에 IMAGES_BUCKET=near-images 필요함.
- 양심고백: 썸네일 url 테스트코드 ai 돌림