### PR TITLE
Near 105 concert rud

### DIFF
--- a/app/core/pagination.py
+++ b/app/core/pagination.py
@@ -1,5 +1,3 @@
-from collections.abc import Sequence
-
 from tortoise import Model
 from tortoise.queryset import QuerySet
 
@@ -10,7 +8,7 @@ async def paginate_cursor[T: Model](
     limit: int,
     cursor_field: str = "id",
     order_by: str = "-id",
-) -> tuple[Sequence[T], int | None]:
+) -> tuple[list[T], int | None]:
     """
     범용 커서 페이지네이션 함수
     """

--- a/app/domains/streams/admin/router.py
+++ b/app/domains/streams/admin/router.py
@@ -16,6 +16,7 @@ from fastapi.templating import Jinja2Templates
 from app.domains.streams import deps as streams_deps
 from app.domains.streams.admin.schemas import (
     ConcertCreateRequest,
+    ConcertDetailResponse,
     ConcertResponse,
     SessionCreateRequest,
     SessionResponse,
@@ -45,6 +46,65 @@ async def create_concert(
     service: StreamAdminService = Depends(streams_deps.get_stream_admin_service),
 ) -> Concert:
     return await service.create_concert(data, current_admin)
+
+
+@router.get(
+    "/concerts",
+    response_model=list[ConcertResponse],
+    summary="콘서트 목록 조회",
+)
+async def list_concerts(
+    response: Response,
+    cursor: int | None = Query(None, description="마지막으로 조회된 콘서트 ID"),
+    limit: int = Query(20, ge=1, le=100),
+    current_admin: User = Depends(get_admin_user),
+    service: StreamAdminService = Depends(streams_deps.get_stream_admin_service),
+) -> list[Concert]:
+    concerts, next_cursor = await service.list_concerts(current_admin, limit, cursor)
+
+    if next_cursor is not None:
+        response.headers["X-Next-Cursor"] = str(next_cursor)
+    return concerts
+
+
+@router.get(
+    "/concerts/{concert_id}",
+    response_model=ConcertDetailResponse,
+    summary="콘서트 상세 조회",
+)
+async def get_concert_detail(
+    concert_id: int = Path(..., description="콘서트 ID"),
+    current_admin: User = Depends(get_admin_user),
+    service: StreamAdminService = Depends(streams_deps.get_stream_admin_service),
+) -> ConcertDetailResponse:
+    return await service.get_concert_detail(concert_id, current_admin)
+
+
+@router.patch(
+    "/concerts/{concert_id}",
+    response_model=ConcertResponse,
+    summary="콘서트 정보 수정",
+)
+async def update_concert(
+    concert_id: int = Path(...),
+    data: ConcertCreateRequest = Body(...),
+    current_admin: User = Depends(get_admin_user),
+    service: StreamAdminService = Depends(streams_deps.get_stream_admin_service),
+) -> Concert:
+    return await service.update_concert(concert_id, data, current_admin)
+
+
+@router.delete(
+    "/concerts/{concert_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="콘서트 및 관련 인프라 전체 삭제",
+)
+async def delete_concert(
+    concert_id: int = Path(...),
+    current_admin: User = Depends(get_admin_user),
+    service: StreamAdminService = Depends(streams_deps.get_stream_admin_service),
+) -> None:
+    return await service.delete_concert_with_infrastructure(concert_id, current_admin)
 
 
 @router.patch(

--- a/app/domains/streams/admin/schemas.py
+++ b/app/domains/streams/admin/schemas.py
@@ -134,6 +134,12 @@ class SessionResponse(BaseModel):
     )
 
 
+class ConcertDetailResponse(ConcertResponse):
+    """콘서트 상세 응답"""
+
+    sessions: list[SessionResponse] = Field(default_factory=list)
+
+
 class StreamIngestResponse(BaseModel):
     """송출 OBS 응답"""
 

--- a/app/domains/streams/admin/service.py
+++ b/app/domains/streams/admin/service.py
@@ -1,4 +1,4 @@
-from typing import Literal, cast
+from typing import Any, Literal, cast
 
 from botocore.exceptions import ClientError
 from fastapi import HTTPException, UploadFile
@@ -9,6 +9,7 @@ from app.core.utils.image_resizer import ImageResizer
 from app.domains.artists.models import Artist
 from app.domains.streams.admin.schemas import (
     ConcertCreateRequest,
+    ConcertDetailResponse,
     IVSChannelSummary,
     SessionCreateRequest,
     SessionResponse,
@@ -75,6 +76,86 @@ class StreamAdminService:
         await concert.save()
 
         return concert
+
+    async def list_concerts(
+        self, user: User, limit: int = 20, cursor: int | None = None
+    ) -> tuple[list[Concert], int | None]:
+        """
+        [Admin] 콘서트 목록 조회
+        """
+        StreamPermission.must_be_admin(user)
+
+        queryset = Concert.all()
+        result: Any = await paginate_cursor(queryset, limit=limit, cursor=cursor, order_by="-id")
+
+        concerts: list[Concert] = result[0]
+        next_cursor: int | None = result[1]
+
+        return concerts, next_cursor
+
+    async def get_concert_detail(self, concert_id: int, user: User) -> ConcertDetailResponse:
+        """
+        [Admin] 콘서트 상세 조회(하위 세션 목록 포함)
+        """
+        StreamPermission.must_be_admin(user)
+
+        concert = await Concert.get_or_none(id=concert_id).prefetch_related(
+            "sessions__stream_channel"
+        )
+
+        if not concert:
+            raise HTTPException(404, "존재하지 않는 콘서트입니다.")
+
+        return ConcertDetailResponse.model_validate(concert)
+
+    async def update_concert(
+        self, concert_id: int, data: ConcertCreateRequest, user: User
+    ) -> Concert:
+        """
+        [Admin] 콘서트 수정
+        """
+        StreamPermission.must_be_admin(user)
+
+        concert = await Concert.get_or_none(id=concert_id)
+        if not concert:
+            raise HTTPException(404, "수정할 콘서트를 찾을 수 없습니다.")
+
+        # 요청 데이터 반영 (exclude_unset=True로 보낸 값만 수정)
+        update_data = data.model_dump(exclude_unset=True)
+        for key, value in update_data.items():
+            setattr(concert, key, value)
+
+        await concert.save()
+        return concert
+
+    async def delete_concert_with_infrastructure(self, concert_id: int, user: User) -> None:
+        """
+        [Admin] 콘서트 삭제 및 AWS IVS 채널 삭제
+        """
+        StreamPermission.must_be_admin(user)
+
+        # 세션, 채널 정보 모두 가져옴
+        concert = await Concert.get_or_none(id=concert_id).prefetch_related(
+            "sessions__stream_channel"
+        )
+
+        if not concert:
+            raise HTTPException(404, "삭제할 콘서트를 찾을 수 없습니다.")
+
+        # 연결된 모든 세션의 AWS IVS 채널 먼저 삭제
+        for session in list(concert.sessions):  # type: ignore[call-overload]
+            if hasattr(session, "stream_channel") and session.stream_channel:
+                try:
+                    self.ivs_client.delete_channel(session.stream_channel.channel_arn)
+                except Exception as e:
+                    logger.warning(f"콘서트 삭제 중 세션({session.id})의 IVS 채널 삭제 실패: {e}")
+
+        # 썸네일 삭제 (S3)
+        if concert.thumbnail_url:
+            await self.image_resizer.delete_all_by_id_path(concert.thumbnail_url)
+
+        # DB 삭제(cascade)
+        await concert.delete()
 
     async def create_session_with_infrastructure(
         self, concert_id: int, data: SessionCreateRequest, user: User

--- a/tests/streams/admin/test_concert_crud.py
+++ b/tests/streams/admin/test_concert_crud.py
@@ -1,0 +1,113 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.domains.streams.admin.schemas import ConcertCreateRequest
+from app.domains.streams.admin.service import StreamAdminService
+from app.domains.streams.models import CategoryType
+
+
+@pytest.fixture
+def stream_admin_service():
+    # IVS 클라이언트와 플레이백 프로바이더는 모킹 처리
+    service = StreamAdminService(MagicMock(), MagicMock())
+    service.image_resizer = AsyncMock()
+    return service
+
+
+@pytest.fixture
+def mock_user_admin():
+    user = MagicMock()
+    user.id = 1
+    user.is_superuser = True
+    return user
+
+
+@pytest.mark.asyncio
+class TestConcertBasicCRUD:
+    @pytest.fixture(autouse=True)
+    def setup(self, stream_admin_service, mock_user_admin):
+        self.service = stream_admin_service
+        self.admin = mock_user_admin
+
+    # 콘서트 생성 테스트
+    async def test_create_concert(self):
+        data = ConcertCreateRequest(title="테스트 콘서트", category=CategoryType.KPOP)
+
+        with patch(
+            "app.domains.streams.models.Concert.create", new_callable=AsyncMock
+        ) as mock_create:
+            mock_create.return_value = MagicMock(id=1, title="테스트 콘서트")
+
+            result = await self.service.create_concert(data, self.admin)
+
+            assert result.title == "테스트 콘서트"
+            mock_create.assert_called_once()
+
+    # 콘서트 리스트 조회 테스트
+    async def test_list_concerts(self):
+        mock_concerts = [MagicMock(id=1), MagicMock(id=2)]
+        with patch(
+            "app.domains.streams.admin.service.paginate_cursor", new_callable=AsyncMock
+        ) as mock_paginate:
+            mock_paginate.return_value = (mock_concerts, 1)
+
+            concerts, next_cursor = await self.service.list_concerts(self.admin, limit=10)
+
+            assert len(concerts) == 2
+            assert next_cursor == 1
+
+    # 콘서트 상세 조회 테스트
+    async def test_get_concert_detail_success(self):
+        concert_id = 1
+        mock_concert = MagicMock(id=concert_id)
+
+        mock_query = MagicMock()
+        mock_query.prefetch_related.return_value = AsyncMock(return_value=mock_concert)()
+
+        with patch("app.domains.streams.models.Concert.get_or_none") as mock_get:
+            mock_get.return_value = mock_query
+
+            with patch("app.domains.streams.admin.schemas.ConcertDetailResponse.model_validate"):
+                await self.service.get_concert_detail(concert_id, self.admin)
+
+                mock_get.assert_called_with(id=concert_id)
+                mock_query.prefetch_related.assert_called_with("sessions__stream_channel")
+
+    # 콘서트 수정 테스트
+    async def test_update_concert(self):
+        concert_id = 1
+        update_data = ConcertCreateRequest(title="수정된 제목", category=CategoryType.KPOP)
+        mock_concert = MagicMock(id=concert_id, title="원본 제목")
+        mock_concert.save = AsyncMock()
+
+        with patch(
+            "app.domains.streams.models.Concert.get_or_none", new_callable=AsyncMock
+        ) as mock_get:
+            mock_get.return_value = mock_concert
+
+            result = await self.service.update_concert(concert_id, update_data, self.admin)
+
+            assert result.title == "수정된 제목"
+            mock_concert.save.assert_called_once()
+
+    # 콘서트 삭제 테스트
+    async def test_delete_concert(self):
+        concert_id = 1
+        mock_concert = MagicMock(id=concert_id, thumbnail_url="path/to/img.jpg")
+        mock_concert.sessions = []
+        mock_concert.delete = AsyncMock()
+
+        mock_query = MagicMock()
+        mock_query.prefetch_related.return_value = AsyncMock(return_value=mock_concert)()
+
+        with patch("app.domains.streams.models.Concert.get_or_none") as mock_get:
+            mock_get.return_value = mock_query
+
+            await self.service.delete_concert_with_infrastructure(concert_id, self.admin)
+
+            # 이미지 삭제 및 DB 삭제 검증
+            self.service.image_resizer.delete_all_by_id_path.assert_called_once_with(
+                "path/to/img.jpg"
+            )
+            mock_concert.delete.assert_called_once()


### PR DESCRIPTION
## ✅ PR 한줄 요약
- 콘서트 rud 추가

## 🔗 관련 이슈
- Jira: NEAR-105

## 🛠️ 변경 내용
- [x] pagination 함수 타입힌트 명확화
- [x] 콘서트 목록조회, 상세조회(딸린 sessions도 함께)
- [x] 콘서트 수정
- [x] 콘서트 삭제 (관련 infrastructure도 같이)

## 🧪 테스트
- [x] 로컬 테스트 완료 (`uv run pytest -q`)
- [x] ruff/mypy 통과 확인
  - [x] `uv run ruff check .`
  - [x] `uv run ruff format --check .`
  - [x] `uv run mypy .`
