### PR TITLE
Near 108 cors and env settings

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -54,6 +54,9 @@ class Settings(BaseSettings):
     ACCESS_TOKEN_EXPIRE_MINUTES: int  # 토큰 유효분
     REFRESH_TOKEN_EXPIRE_DAYS: int = 7  # 리프레시 토큰 유효일
 
+    # CORS 설정
+    CORS_ORIGINS: list[str] = []
+
     # ADMIN 계정
     ADMIN_USERNAME: str
     ADMIN_PASSWORD: str

--- a/app/main.py
+++ b/app/main.py
@@ -17,9 +17,11 @@ from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING
 
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 from tortoise import Tortoise
 
 from app.api.router import api_router
+from app.core.config import settings
 from app.core.tortoise_config import TORTOISE_ORM
 
 if TYPE_CHECKING:
@@ -47,6 +49,15 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 
 
 app = FastAPI(title="NEAR0.5 API", lifespan=lifespan)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=settings.CORS_ORIGINS,  # 허용할 도메인 목록
+    allow_credentials=True,  # 쿠키(토큰) 포함 허용
+    allow_methods=["*"],  # GET, POST, DELETE 등 모든 메서드 허용
+    allow_headers=["*"],  # 모든 헤더 허용
+    expose_headers=["Content-Disposition", "Custom-Header"],  # 명시적으로 노출해야만 접근 가능
+)
 
 # v1 라우터 조립(도메인 라우터는 app/api/router.py에서 관리)
 app.include_router(api_router)


### PR DESCRIPTION
## ✅ PR 한줄 요약
- 프론트엔드 배포 및 로컬 개발 환경의 API 접근 허용을 위한 CORS 설정 도입과 환경 변수 파싱 구조를 개선했습니다.

## 🔗 관련 이슈
- Jira: NEAR-108
- GitHub: #

## 🛠️ 변경 내용
- [x] CORS 미들웨어 도입: main.py에 CORSMiddleware를 추가하여 프론트엔드(near-0-5.vercel.app) 및 로컬 환경에서의 교차 출처 요청 허용
- [x] 환경 변수 구조 최적화: .env의 CORS_ORIGINS 문자열을 Pydantic Settings에서 list[str]로 자동 파싱하도록 설정
- [x] 보안 및 인증 설정: 소셜 로그인 및 세션 관리를 위해 allow_credentials=True를 설정하여 쿠키 전송 허용

## 🧪 테스트
- [x] 로컬 테스트 완료 (`uv run pytest -q`)
- [x] ruff/mypy 통과 확인
  - [x] `uv run ruff check .`
  - [x] `uv run ruff format --check .`
  - [x] `uv run mypy .`

## ⚠️ 리뷰 포인트 / 주의사항
- 환경 변수 형식: .env 파일의 CORS_ORIGINS 값이 반드시 JSON 리스트 형식('["url1", "url2"]')으로 작성되어야 Pydantic에서 정상적으로 리스트로 인식합니다.
- 

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했습니다.
- [x] 불필요한 주석/로그를 제거했습니다.
- [x] 문서/설정 변경이 필요하면 반영했습니다.