### PR TITLE
[NEAR-81] Feat: implement artist unfollow and reorganize router methods

### DIFF
--- a/app/domains/users/router.py
+++ b/app/domains/users/router.py
@@ -54,13 +54,6 @@ async def update_my_profile(
     return await user_service.update_user_profile(current_user, data)
 
 
-@router.post("/me/image", summary="프로필 이미지 업로드")
-async def upload_my_profile_image(
-    current_user: Annotated[User, Depends(get_current_user)], file: UploadFile = File(...)
-) -> UserMeResponse:
-    return await user_service.update_profile_image(current_user, file)
-
-
 @router.delete("/me", summary="회원 탈퇴", status_code=status.HTTP_204_NO_CONTENT)
 async def withdraw(
     response: Response,
@@ -74,6 +67,13 @@ async def withdraw(
     response.delete_cookie(key="refresh_token", path="/")
 
     return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.post("/me/image", summary="프로필 이미지 업로드")
+async def upload_my_profile_image(
+    current_user: Annotated[User, Depends(get_current_user)], file: UploadFile = File(...)
+) -> UserMeResponse:
+    return await user_service.update_profile_image(current_user, file)
 
 
 @router.get(
@@ -101,3 +101,24 @@ async def add_my_favorite_artist(
     data: FavoriteArtistCreate, current_user: User = Depends(get_current_user)
 ) -> FavoriteArtistResponse:
     return await user_service.add_follow_artist(current_user, data)
+
+
+@router.delete(
+    "/me/favorite-artists/{artist_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="사용자의 선호 아티스트 삭제",
+    description="현재 로그인한 사용자가 팔로우 중인 특정 아티스트를 목록에서 삭제합니다.",
+    responses={
+        204: {"description": "삭제 성공"},
+        401: {"description": "인증되지 않은 사용자"},
+        404: {"description": "팔로우 중인 아티스트(ID: {artist_id})를 찾을 수 없습니다."},
+    },
+)
+async def unfollow_artist(
+    artist_id: int,
+    current_user: User = Depends(get_current_user),
+) -> Response:
+    """
+    선호 아티스트(팔로우)를 취소합니다.
+    """
+    return await user_service.remove_follow_artist(current_user, artist_id)

--- a/app/domains/users/service.py
+++ b/app/domains/users/service.py
@@ -2,7 +2,7 @@ from datetime import UTC, datetime
 from typing import cast
 
 import httpx
-from fastapi import HTTPException, UploadFile, status
+from fastapi import HTTPException, Response, UploadFile, status
 from tortoise.transactions import in_transaction
 
 from app.core.config import settings
@@ -196,6 +196,25 @@ class UserService:
             profile_img_url=artist.profile_img_url,  # alias 설정에 따라 매핑
             created_at=follow.created_at,  # Follow 모델의 생성일
         )
+
+    async def remove_follow_artist(self, user: User, artist_id: int) -> Response:
+        """
+        사용자가 요청한 선호 아티스트를 삭제(언팔로우)합니다.
+        """
+        # 팔로우 관계 존재 여부 확인
+        follow = await Follow.get_or_none(user=user, artist_id=artist_id)
+
+        if not follow:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"팔로우 중인 아티스트(ID: {artist_id})를 찾을 수 없습니다.",
+            )
+
+        # 팔로우 기록 삭제
+        await follow.delete()
+
+        # 성공하면
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 user_service: UserService = UserService()


### PR DESCRIPTION
✅ PR 한줄 요약
* 사용자가 본인의 선호 아티스트 목록에서 특정 아티스트를 삭제할 수 있는 언팔로우(Unfollow) 기능을 구현했습니다.

🔗 관련 이슈
* Jira: NEAR-81
* GitHub: #

🛠️ 변경 내용
* [x] UserService 삭제 로직 추가: Follow 모델에서 사용자 ID와 아티스트 ID를 매칭하여 레코드를 삭제하는 remove_follow_artist 메서드 구현
* [x] 유효성 검사 적용: 삭제하려는 팔로우 기록이 없을 경우 404 Not Found 예외를 발생시켜 데이터 무결성 확보
* [x] Router 엔드포인트 구현: DELETE /api/v1/users/me/favorite-artists/{artist_id} 경로를 추가하고 성공 시 204 No Content 응답 반환
🧪 테스트
* [x] 로컬 테스트 완료 (uv run pytest -q)
* [x] ruff/mypy 통과 확인
    * [x] uv run ruff check .
    * [x] uv run ruff format --check .
    * [x] uv run mypy .
* [x] (선택) Postman/Swagger를 통해 실제 DB 레코드 삭제 여부 확인 완료

⚠️ 리뷰 포인트 / 주의사항
* 응답 객체 처리: service.py에서 Response(status_code=status.HTTP_204_NO_CONTENT)를 직접 반환하도록 하였습니다.
* 권한 확인: get_current_user 의존성을 통해 본인의 팔로우 기록만 삭제할 수 있도록 강제했습니다.
* ** 코드리뷰반영전 코드입니다.** : 프론트에서의 api 연결을 위하여 먼저 올립니다.    

✅ 체크리스트
* [x] 커밋 메시지 컨벤션을 준수했습니다.
* [x] 불필요한 주석/로그를 제거했습니다.
* [x] 문서/설정 변경이 필요하면 반영했습니다.