### PR TITLE
Near 112 reschedule notifications on session start change

### DIFF
--- a/app/domains/notifications/service.py
+++ b/app/domains/notifications/service.py
@@ -168,6 +168,23 @@ class NotificationService:
 
         return total_created
 
+    async def reschedule_session_notifications(
+        self, session_id: int, *, session: ConcertSession | None = None
+    ) -> int:
+        """기존 예정 알림(PENDING/FAILED) 삭제 후 새 스케줄 생성."""
+        if session is None:
+            session = await ConcertSession.get(id=session_id)
+        await session.fetch_related("concert", "lineup")
+
+        if session.status == StreamStatus.ENDED:
+            return 0
+
+        await ConcertNoti.filter(
+            session_id=session.id, status__in=[NotiStatus.PENDING, NotiStatus.FAILED]
+        ).delete()
+
+        return await self.schedule_session_notifications(session.id, session=session)
+
     async def schedule_upcoming_sessions(self, hours_ahead: int = 24) -> int:
         """지금부터 N시간 이내 시작하는 세션들의 알림을 생성."""
         now = now_kst()

--- a/app/domains/streams/admin/service.py
+++ b/app/domains/streams/admin/service.py
@@ -26,6 +26,7 @@ from app.domains.streams.models import (
     StreamChannel,
     StreamStatus,
 )
+from app.domains.notifications.service import notification_service
 from app.domains.streams.permissions import StreamPermission
 from app.domains.users.models import User
 from app.integrations.aws_ivs import IVSClient, IVSPlaybackProvider
@@ -443,6 +444,7 @@ class StreamAdminService:
             raise HTTPException(404, "해당 콘서트 세션을 찾을 수 없습니다.")
 
         channel = getattr(session, "stream_channel", None)
+        start_at_before = session.start_at
 
         # DB 수정
         update_dict = data.model_dump(exclude={"channel_config", "artist_ids"}, exclude_unset=True)
@@ -494,6 +496,9 @@ class StreamAdminService:
             await channel.save()
 
         await session.save()
+
+        if data.start_at is not None and data.start_at != start_at_before:
+            await notification_service.reschedule_session_notifications(session.id, session=session)
 
         # 업데이트된 정보로 다시 조회하여 반환
         return await self.get_session_admin_detail(session_id, user)

--- a/app/domains/streams/admin/service.py
+++ b/app/domains/streams/admin/service.py
@@ -7,6 +7,7 @@ from mypy_boto3_ivs.type_defs import GetStreamResponseTypeDef
 from app.core.pagination import paginate_cursor
 from app.core.utils.image_resizer import ImageResizer
 from app.domains.artists.models import Artist
+from app.domains.notifications.service import notification_service
 from app.domains.streams.admin.schemas import (
     ConcertCreateRequest,
     ConcertDetailResponse,
@@ -26,7 +27,6 @@ from app.domains.streams.models import (
     StreamChannel,
     StreamStatus,
 )
-from app.domains.notifications.service import notification_service
 from app.domains.streams.permissions import StreamPermission
 from app.domains.users.models import User
 from app.integrations.aws_ivs import IVSClient, IVSPlaybackProvider


### PR DESCRIPTION
## ✅ PR 한줄 요약
- 세션 시작시간 변경 시 기존 예정 알림을 삭제하고 새 스케줄로 재생성되도록 하여 알림 시간이 정확히 반영되도록 변경

## 🔗 관련 이슈
- Jira: NEAR-112

## 🛠️ 변경 내용
- [x] 세션 시작시간 변경 감지 시 알림 재스케줄 호출 추가
- [x] 기존 예정 알림(PENDING/FAILED) 삭제 후 재생성 로직 추가

## ⚠️ 리뷰 포인트 / 주의사항
- 라인업 변경 시 알림 재스케줄은 미포함인데 의견 부탁