### PR TITLE
Near 110 aws ivs webhook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,8 +99,9 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       AWS_REGION: ap-northeast-2
       IVS_PLAYBACK_PRIVATE_KEY_B64: ${{ secrets.IVS_PLAYBACK_PRIVATE_KEY_B64 }}
-      S3_RECORDING_BUCKET: my-concert-ivs-recordings
+      S3_RECORDING_BUCKET: ${{ secrets.S3_RECORDING_BUCKET }}
       IMAGES_BUCKET: ${{ secrets.IMAGES_BUCKET }}
+      IVS_WEBHOOK_SECRET: ${{ secrets.IVS_WEBHOOK_SECRET }}
 
       ADMIN_SECRET_KEY: ${{ secrets.ADMIN_SECRET_KEY }}
       ADMIN_USERNAME: admin
@@ -112,12 +113,12 @@ jobs:
 
       ACCESS_TOKEN_EXPIRE_MINUTES: 15
       REFRESH_TOKEN_EXPIRE_DAYS: 7
-      KAKAO_REST_API_KEY: "aa01acb6e04a9e4c04543d5834ee68ae"
-      KAKAO_REDIRECT_URI: "http://52.78.124.109:8000/auth/kakao/callback"
-      KAKAO_CLIENT_SECRET: "GPFeAF5PbNB41dSF2iTBdwSKoD1krunt"
-      KAKAO_ADMIN_KEY: "be42a537604c50c5673929aa78daa7e5"
-      CALLBACK_REDIRECT_URL: "http://52.78.124.109:8000/docs"
-      CORS_ORIGINS: '["https://near-0-5.vercel.app", "http://localhost:5173", "http://localhost:3000"]'
+      KAKAO_REST_API_KEY: ${{ secrets.KAKAO_REST_API_KEY }}
+      KAKAO_REDIRECT_URI: ${{ secrets.KAKAO_REDIRECT_URI }}
+      KAKAO_CLIENT_SECRET: ${{ secrets.KAKAO_CLIENT_SECRET }}
+      KAKAO_ADMIN_KEY: ${{ secrets.KAKAO_ADMIN_KEY }}
+      CALLBACK_REDIRECT_URL: ${{ secrets.CALLBACK_REDIRECT_URL }}
+      CORS_ORIGINS: ${{ secrets.CORS_ORIGINS }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,7 @@ jobs:
       KAKAO_CLIENT_SECRET: ${{ secrets.KAKAO_CLIENT_SECRET }}
       KAKAO_ADMIN_KEY: ${{ secrets.KAKAO_ADMIN_KEY }}
       CALLBACK_REDIRECT_URL: ${{ secrets.CALLBACK_REDIRECT_URL }}
-      CORS_ORIGINS: ${{ secrets.CORS_ORIGINS }}
+      CORS_ORIGINS: '${{ secrets.CORS_ORIGINS }}'
 
     steps:
       - name: Checkout code

--- a/app/api/router.py
+++ b/app/api/router.py
@@ -1,22 +1,12 @@
-"""API 라우터 조립 파일.
-
-여기에 넣을 것:
-- 각 도메인의 router를 import해서 include_router로 모아두기
-- 버저닝(prefix='/api/v1') 같은 공통 prefix 적용
-
-예:
-- auth_router: /auth
-- users_router: /users, /me
-- streams_router: /streams
-"""
-
 from fastapi import APIRouter
 
 from app.domains.artists.router import router as artists_router
 from app.domains.auth.router import router as auth_router
 from app.domains.chat.router_ws import router as chat_router
 from app.domains.notifications.router import router as notifications_router
-from app.domains.streams.admin.router import router as streams_admin_router
+from app.domains.streams.admin.concert_router import router as concert_admin_router
+from app.domains.streams.admin.ivs_webhook_router import router as streams_status_router
+from app.domains.streams.admin.stream_router import router as streams_admin_router
 from app.domains.streams.client.router import router as streams_router
 from app.domains.users.router import router as users_router
 
@@ -26,7 +16,9 @@ api_router = APIRouter(prefix="/api/v1")
 api_router.include_router(auth_router)
 api_router.include_router(users_router)
 api_router.include_router(artists_router)
+api_router.include_router(concert_admin_router)
 api_router.include_router(streams_router)
+api_router.include_router(streams_status_router)
 api_router.include_router(streams_admin_router)
 api_router.include_router(chat_router)
 api_router.include_router(notifications_router)

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -73,6 +73,7 @@ class Settings(BaseSettings):
     IVS_PLAYBACK_PRIVATE_KEY_B64: str = Field(..., validation_alias="IVS_PLAYBACK_PRIVATE_KEY_B64")
     S3_RECORDING_BUCKET: str
     IMAGES_BUCKET: str
+    IVS_WEBHOOK_SECRET: str
 
     # social_login
     KAKAO_REST_API_KEY: str

--- a/app/domains/auth/router.py
+++ b/app/domains/auth/router.py
@@ -30,7 +30,7 @@ async def admin_login(
         key="refresh_token",
         value=refresh_token,
         httponly=True,  # 자바스크립트 접근 방지 (보안)
-        samesite="lax",  # CSRF 방지
+        samesite="none",
         secure=True,  # HTTPS에서 활성화
         max_age=60 * 60 * 24 * 7,  # 7일간 유지
     )

--- a/app/domains/notifications/models.py
+++ b/app/domains/notifications/models.py
@@ -52,14 +52,14 @@ class ConcertNoti(models.Model):
         user_id: int
         session_id: int
 
-    kind = fields.CharEnumField(NotiKind, index=True)
+    kind = fields.CharEnumField(NotiKind, db_index=True)
 
     title = fields.CharField(max_length=100)
     message = fields.TextField()
 
-    send_at = fields.DatetimeField(index=True)
+    send_at = fields.DatetimeField(db_index=True)
 
-    status = fields.CharEnumField(NotiStatus, default=NotiStatus.PENDING, index=True)
+    status = fields.CharEnumField(NotiStatus, default=NotiStatus.PENDING, db_index=True)
     sent_at = fields.DatetimeField(null=True)
 
     created_at = fields.DatetimeField(auto_now_add=True)

--- a/app/domains/notifications/tasks.py
+++ b/app/domains/notifications/tasks.py
@@ -34,6 +34,16 @@ def schedule_session_notifications(session_id: int) -> int:
 
 
 @celery_app.task(  # type: ignore[untyped-decorator]
+    name="app.domains.notifications.tasks.reschedule_session_notifications"
+)
+def reschedule_session_notifications(session_id: int) -> int:
+    """세션 변경 시 기존 알림 취소 후 재스케줄링"""
+    return asyncio.run(
+        _run_with_db(notification_service.reschedule_session_notifications(session_id))
+    )
+
+
+@celery_app.task(  # type: ignore[untyped-decorator]
     name="app.domains.notifications.tasks.schedule_upcoming_session_notifications"
 )
 def schedule_upcoming_session_notifications(hours_ahead: int = 24) -> int:

--- a/app/domains/streams/admin/concert_router.py
+++ b/app/domains/streams/admin/concert_router.py
@@ -1,0 +1,117 @@
+from fastapi import (
+    APIRouter,
+    Body,
+    Depends,
+    File,
+    Path,
+    Query,
+    Response,
+    UploadFile,
+    status,
+)
+
+from app.domains.streams import deps as streams_deps
+from app.domains.streams.admin.schemas import (
+    ConcertCreateRequest,
+    ConcertDetailResponse,
+    ConcertResponse,
+)
+from app.domains.streams.admin.service import StreamAdminService
+from app.domains.streams.deps import get_admin_user
+from app.domains.streams.models import Concert
+from app.domains.users.models import User
+
+router = APIRouter(prefix="/admin/concerts", tags=["콘서트 관리"])
+
+
+@router.post(
+    "",
+    status_code=status.HTTP_201_CREATED,
+    response_model=ConcertResponse,
+    summary="콘서트 메타정보 생성",
+    description="신규 콘서트의 기본 메타데이터(제목, 카테고리 등)를 생성합니다. \
+    인프라 리소스는 생성되지 않습니다.",
+)
+async def create_concert(
+    data: ConcertCreateRequest,
+    current_admin: User = Depends(get_admin_user),
+    service: StreamAdminService = Depends(streams_deps.get_stream_admin_service),
+) -> Concert:
+    return await service.create_concert(data, current_admin)
+
+
+@router.get(
+    "",
+    response_model=list[ConcertResponse],
+    summary="콘서트 목록 조회",
+)
+async def list_concerts(
+    response: Response,
+    cursor: int | None = Query(None, description="마지막으로 조회된 콘서트 ID"),
+    limit: int = Query(20, ge=1, le=100),
+    current_admin: User = Depends(get_admin_user),
+    service: StreamAdminService = Depends(streams_deps.get_stream_admin_service),
+) -> list[Concert]:
+    concerts, next_cursor = await service.list_concerts(current_admin, limit, cursor)
+
+    if next_cursor is not None:
+        response.headers["X-Next-Cursor"] = str(next_cursor)
+    return concerts
+
+
+@router.get(
+    "/{concert_id}",
+    response_model=ConcertDetailResponse,
+    summary="콘서트 상세 조회",
+)
+async def get_concert_detail(
+    concert_id: int = Path(..., description="콘서트 ID"),
+    current_admin: User = Depends(get_admin_user),
+    service: StreamAdminService = Depends(streams_deps.get_stream_admin_service),
+) -> ConcertDetailResponse:
+    return await service.get_concert_detail(concert_id, current_admin)
+
+
+@router.patch(
+    "/{concert_id}",
+    response_model=ConcertResponse,
+    summary="콘서트 정보 수정",
+)
+async def update_concert(
+    concert_id: int = Path(...),
+    data: ConcertCreateRequest = Body(...),
+    current_admin: User = Depends(get_admin_user),
+    service: StreamAdminService = Depends(streams_deps.get_stream_admin_service),
+) -> Concert:
+    return await service.update_concert(concert_id, data, current_admin)
+
+
+@router.delete(
+    "/{concert_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="콘서트 및 관련 인프라 전체 삭제",
+)
+async def delete_concert(
+    concert_id: int = Path(...),
+    current_admin: User = Depends(get_admin_user),
+    service: StreamAdminService = Depends(streams_deps.get_stream_admin_service),
+) -> None:
+    return await service.delete_concert_with_infrastructure(concert_id, current_admin)
+
+
+@router.patch(
+    "/{concert_id}/thumbnail",
+    response_model=ConcertResponse,
+    summary="콘서트 썸네일 이미지 생성 및 수정",
+    description="콘서트 썸네일 이미지를 업로드 또는 수정합니다.",
+)
+async def update_concert_thumbnail(
+    current_admin: User = Depends(get_admin_user),
+    concert_id: int = Path(..., description="콘서트 ID"),
+    thumbnail_file: UploadFile = File(..., description="썸네일 이미지 파일"),
+    service: StreamAdminService = Depends(streams_deps.get_stream_admin_service),
+) -> Concert:
+    # 인증된 current_admin 객체를 서비스로 직접 전달
+    return await service.update_concert_thumbnail(
+        concert_id=concert_id, file=thumbnail_file, user=current_admin
+    )

--- a/app/domains/streams/admin/ivs_webhook_router.py
+++ b/app/domains/streams/admin/ivs_webhook_router.py
@@ -1,0 +1,26 @@
+from fastapi import APIRouter, Depends, Header, HTTPException, status
+
+from app.core.config import settings
+from app.domains.streams.admin.schemas import StreamWebhookPayload
+from app.domains.streams.admin.service import StreamAdminService
+from app.domains.streams.deps import get_stream_admin_service
+
+router = APIRouter(prefix="/streams/webhook", tags=["스트리밍 웹훅"])
+
+
+@router.post(
+    "", status_code=status.HTTP_200_OK, summary="IVS 상태 변경 웹훅", include_in_schema=False
+)
+async def ivs_webhook_handler(
+    payload: StreamWebhookPayload,
+    x_api_key: str | None = Header(None, alias="X-API-Key"),
+    service: StreamAdminService = Depends(get_stream_admin_service),
+) -> None:
+    """
+    AWS EventBridge IVS 상태 변경 수신
+    """
+    # 보안 키 확인
+    if not x_api_key or x_api_key != settings.IVS_WEBHOOK_SECRET:
+        raise HTTPException(status_code=403, detail="Invalid API Key")
+
+    await service.handle_ivs_webhook(payload)

--- a/app/domains/streams/admin/schemas.py
+++ b/app/domains/streams/admin/schemas.py
@@ -151,3 +151,26 @@ class StreamIngestResponse(BaseModel):
     playback_url: str
     playback_token: str | None = None
     live_metrics: StreamLiveMetrics | None = None
+
+
+# ========================= IVS 상태 동기회 웹훅 =========================
+class IVSDetail(BaseModel):
+    channel_name: str | None = Field(None, alias="channel_name")
+    stream_id: str | None = Field(None, alias="stream_id")
+    channel_arn: str | None = Field(..., alias="channel_arn")
+    event_name: str | None = Field(..., alias="event_name")  # Stream Start | Stream End
+
+
+class IVSEvent(BaseModel):
+    version: str
+    id: str
+    detail_type: str = Field(..., alias="detail_type")  # IVS Stream State Change
+    source: str
+    time: str
+    region: str
+    resources: list[str]
+    detail: IVSDetail
+
+
+class StreamWebhookPayload(IVSEvent):
+    pass

--- a/app/domains/streams/admin/schemas.py
+++ b/app/domains/streams/admin/schemas.py
@@ -162,9 +162,10 @@ class IVSDetail(BaseModel):
 
 
 class IVSEvent(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     version: str
     id: str
-    detail_type: str = Field(..., alias="detail_type")  # IVS Stream State Change
+    detail_type: str = Field(..., alias="detail-type")  # IVS Stream State Change
     source: str
     time: str
     region: str

--- a/app/domains/streams/admin/service.py
+++ b/app/domains/streams/admin/service.py
@@ -4,10 +4,15 @@ from botocore.exceptions import ClientError
 from fastapi import HTTPException, UploadFile
 from mypy_boto3_ivs.type_defs import GetStreamResponseTypeDef
 
+from app.core.config import now_kst
 from app.core.pagination import paginate_cursor
 from app.core.utils.image_resizer import ImageResizer
 from app.domains.artists.models import Artist
-from app.domains.notifications.service import notification_service
+from app.domains.notifications.tasks import (
+    dispatch_due_notifications,
+    reschedule_session_notifications,
+    schedule_session_notifications,
+)
 from app.domains.streams.admin.schemas import (
     ConcertCreateRequest,
     ConcertDetailResponse,
@@ -18,6 +23,7 @@ from app.domains.streams.admin.schemas import (
     StreamIngestInfo,
     StreamIngestResponse,
     StreamLiveMetrics,
+    StreamWebhookPayload,
 )
 from app.domains.streams.models import (
     AccessLevel,
@@ -25,6 +31,7 @@ from app.domains.streams.models import (
     ConcertArtist,
     ConcertSession,
     StreamChannel,
+    StreamSession,
     StreamStatus,
 )
 from app.domains.streams.permissions import StreamPermission
@@ -39,6 +46,7 @@ class StreamAdminService:
         self.playback_provider = playback_provider
         self.image_resizer = ImageResizer()
 
+    # ================================ 콘서트 관리 ====================================
     async def create_concert(self, data: ConcertCreateRequest, user: User) -> Concert:
         """
         [Admin] 콘서트 생성
@@ -158,6 +166,54 @@ class StreamAdminService:
         # DB 삭제(cascade)
         await concert.delete()
 
+    # ================================ IVS 상태 웹훅 ===================================
+    async def handle_ivs_webhook(self, payload: StreamWebhookPayload) -> None:
+        detail = payload.detail
+        event_name = detail.event_name  # "Stream Start" | "Stream End"
+        channel_arn = detail.channel_arn
+        stream_id = detail.stream_id
+
+        # 채널 찾기
+        channel = await StreamChannel.get_or_none(channel_arn=channel_arn).prefetch_related(
+            "session"
+        )
+        if not channel:
+            return  # 알 수 없는 채널 무시
+
+        session: ConcertSession = channel.session
+        now = now_kst()
+
+        # 방송 시작 (Stream Start)
+        if event_name == "Stream Start":
+            # 상태 변경
+            session.status = StreamStatus.LIVE
+            await session.save(update_fields=["status"])
+
+            # 스트리밍 이력 생성
+            if stream_id:
+                await StreamSession.create(session=session, stream_id=stream_id, started_at=now)
+
+            # 라이브 시작 알림 즉시 발송 트리거
+            dispatch_due_notifications.delay()
+
+        # 방송 종료 (Stream End)
+        elif event_name == "Stream End":
+            # 종료 상태 처리 (예정 종료 시간이 지났으면 ENDED, 아니면 READY)
+            if session.end_at and now > session.end_at:
+                session.status = StreamStatus.ENDED
+            else:
+                session.status = StreamStatus.READY
+
+            await session.save(update_fields=["status"])
+
+            # 이력 종료 시간 기록
+            if stream_id:
+                stream_session = await StreamSession.get_or_none(stream_id=stream_id)
+                if stream_session:
+                    stream_session.ended_at = now
+                    await stream_session.save(update_fields=["ended_at"])
+
+    # ================================ 세션 관리 =====================================
     async def create_session_with_infrastructure(
         self, concert_id: int, data: SessionCreateRequest, user: User
     ) -> SessionResponse:
@@ -245,6 +301,8 @@ class StreamAdminService:
             raise HTTPException(500, f"IVS 채널 생성 실패: {str(e)}") from e
 
         from app.domains.streams.admin.schemas import IVSChannelSummary
+
+        schedule_session_notifications.delay(session.id)
 
         return SessionResponse(
             id=session.id,
@@ -498,7 +556,7 @@ class StreamAdminService:
         await session.save()
 
         if data.start_at is not None and data.start_at != start_at_before:
-            await notification_service.reschedule_session_notifications(session.id, session=session)
+            reschedule_session_notifications.delay(session.id)
 
         # 업데이트된 정보로 다시 조회하여 반환
         return await self.get_session_admin_detail(session_id, user)

--- a/app/domains/streams/admin/stream_router.py
+++ b/app/domains/streams/admin/stream_router.py
@@ -2,12 +2,10 @@ from fastapi import (
     APIRouter,
     Body,
     Depends,
-    File,
     Path,
     Query,
     Request,
     Response,
-    UploadFile,
     status,
 )
 from fastapi.responses import HTMLResponse
@@ -15,9 +13,6 @@ from fastapi.templating import Jinja2Templates
 
 from app.domains.streams import deps as streams_deps
 from app.domains.streams.admin.schemas import (
-    ConcertCreateRequest,
-    ConcertDetailResponse,
-    ConcertResponse,
     SessionCreateRequest,
     SessionResponse,
     SessionUpdateRequest,
@@ -25,104 +20,10 @@ from app.domains.streams.admin.schemas import (
 )
 from app.domains.streams.admin.service import StreamAdminService
 from app.domains.streams.deps import get_admin_user
-from app.domains.streams.models import Concert
 from app.domains.users.models import User
 
-router = APIRouter(prefix="/admin/streams", tags=["[Admin] 스트리밍 관리"])
+router = APIRouter(prefix="/admin/streams", tags=["스트리밍 관리"])
 templates = Jinja2Templates(directory="templates")
-
-
-@router.post(
-    "/concerts",
-    status_code=status.HTTP_201_CREATED,
-    response_model=ConcertResponse,
-    summary="콘서트 메타정보 생성",
-    description="신규 콘서트의 기본 메타데이터(제목, 카테고리 등)를 생성합니다. \
-    인프라 리소스는 생성되지 않습니다.",
-)
-async def create_concert(
-    data: ConcertCreateRequest,
-    current_admin: User = Depends(get_admin_user),
-    service: StreamAdminService = Depends(streams_deps.get_stream_admin_service),
-) -> Concert:
-    return await service.create_concert(data, current_admin)
-
-
-@router.get(
-    "/concerts",
-    response_model=list[ConcertResponse],
-    summary="콘서트 목록 조회",
-)
-async def list_concerts(
-    response: Response,
-    cursor: int | None = Query(None, description="마지막으로 조회된 콘서트 ID"),
-    limit: int = Query(20, ge=1, le=100),
-    current_admin: User = Depends(get_admin_user),
-    service: StreamAdminService = Depends(streams_deps.get_stream_admin_service),
-) -> list[Concert]:
-    concerts, next_cursor = await service.list_concerts(current_admin, limit, cursor)
-
-    if next_cursor is not None:
-        response.headers["X-Next-Cursor"] = str(next_cursor)
-    return concerts
-
-
-@router.get(
-    "/concerts/{concert_id}",
-    response_model=ConcertDetailResponse,
-    summary="콘서트 상세 조회",
-)
-async def get_concert_detail(
-    concert_id: int = Path(..., description="콘서트 ID"),
-    current_admin: User = Depends(get_admin_user),
-    service: StreamAdminService = Depends(streams_deps.get_stream_admin_service),
-) -> ConcertDetailResponse:
-    return await service.get_concert_detail(concert_id, current_admin)
-
-
-@router.patch(
-    "/concerts/{concert_id}",
-    response_model=ConcertResponse,
-    summary="콘서트 정보 수정",
-)
-async def update_concert(
-    concert_id: int = Path(...),
-    data: ConcertCreateRequest = Body(...),
-    current_admin: User = Depends(get_admin_user),
-    service: StreamAdminService = Depends(streams_deps.get_stream_admin_service),
-) -> Concert:
-    return await service.update_concert(concert_id, data, current_admin)
-
-
-@router.delete(
-    "/concerts/{concert_id}",
-    status_code=status.HTTP_204_NO_CONTENT,
-    summary="콘서트 및 관련 인프라 전체 삭제",
-)
-async def delete_concert(
-    concert_id: int = Path(...),
-    current_admin: User = Depends(get_admin_user),
-    service: StreamAdminService = Depends(streams_deps.get_stream_admin_service),
-) -> None:
-    return await service.delete_concert_with_infrastructure(concert_id, current_admin)
-
-
-@router.patch(
-    "/concerts/{concert_id}/thumbnail",
-    response_model=ConcertResponse,
-    summary="콘서트 썸네일 이미지 생성 및 수정",
-    description="콘서트 썸네일 이미지를 업로드 또는 수정합니다.",
-)
-async def update_concert_thumbnail(
-    current_admin: User = Depends(get_admin_user),
-    concert_id: int = Path(..., description="콘서트 ID"),
-    thumbnail_file: UploadFile = File(..., description="썸네일 이미지 파일"),
-    service: StreamAdminService = Depends(streams_deps.get_stream_admin_service),
-) -> Concert:
-    # 인증된 current_admin 객체를 서비스로 직접 전달
-    return await service.update_concert_thumbnail(
-        concert_id=concert_id, file=thumbnail_file, user=current_admin
-    )
 
 
 @router.post(

--- a/app/domains/streams/admin/stream_router.py
+++ b/app/domains/streams/admin/stream_router.py
@@ -170,6 +170,7 @@ async def stream_monitor_page(
     current_admin: User = Depends(get_admin_user),
 ) -> HTMLResponse:
     return templates.TemplateResponse(
+        request,
         "stream_monitor.html",
-        {"request": request, "session_id": session_id, "is_admin": current_admin.is_superuser},
+        {"session_id": session_id, "is_admin": current_admin.is_superuser},
     )

--- a/infra/cfn/20-core-services.yml
+++ b/infra/cfn/20-core-services.yml
@@ -23,8 +23,9 @@ Resources:
     Properties:
       GroupDescription: Allow SSH and FastAPI App
       SecurityGroupIngress:
-        - { IpProtocol: tcp, FromPort: 22, ToPort: 22, CidrIp: 0.0.0.0/0 }
-        - { IpProtocol: tcp, FromPort: 8000, ToPort: 8000, CidrIp: 0.0.0.0/0 }
+        - { IpProtocol: tcp, FromPort: 22, ToPort: 22, CidrIp: 0.0.0.0/0 }      # SSH 접속용
+        - { IpProtocol: tcp, FromPort: 8000, ToPort: 8000, SourcePrefixListId: pl-adb2ceca }  # FastAPI(Uvicorn) 직접 수신용
+
 
   # IVS 녹화 설정
   MyIVSRecordingConfig:

--- a/infra/cfn/30-eventbridge-webhook.yml
+++ b/infra/cfn/30-eventbridge-webhook.yml
@@ -1,0 +1,69 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: IVS Events to FastAPI Webhook via EventBridge
+
+Parameters:
+  # CloudFront 도메인 주소와 FastAPI 웹훅 경로
+  WebhookUrl:
+    Type: String
+    Default: "https://d15qsadcdtxaqn.cloudfront.net/api/v1/streams/webhook"
+  IVSWebhookSecret:
+    Type: String
+    NoEcho: True
+    Description: "Enter the secret key for X-API-Key to validate requests in FastAPI"
+
+Resources:
+  # EventBridge가 웹훅을 호출할 수 있는 권한(Role)
+  EventBridgeRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: events.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: EventBridgeInvokeApi
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action: events:InvokeApiDestination
+                Resource: !Sub "arn:aws:events:${AWS::Region}:${AWS::AccountId}:api-destination/*"
+
+  # 웹훅 전송 대상 설정 (FastAPI 서버 주소)
+  MyApiDestination:
+    Type: AWS::Events::ApiDestination
+    Properties:
+      Name: near05-webhook
+      ConnectionArn: !GetAtt MyEventConnection.Arn
+      InvocationEndpoint: !Ref WebhookUrl
+      HttpMethod: POST
+
+  # 인증 설정 (FastAPI에서 보안 확인용으로 쓸 수 있는 헤더)
+  MyEventConnection:
+    Type: AWS::Events::Connection
+    Properties:
+      Name: near05-webhook-connection
+      AuthorizationType: API_KEY
+      AuthParameters:
+        ApiKeyAuthParameters:
+          ApiKeyName: "X-API-Key"
+          ApiKeyValue: !Ref IVSWebhookSecret
+
+  # IVS 상태 변경 감지 규칙 (방송 시작/종료 시 트리거)
+  IVSStatusRule:
+    Type: AWS::Events::Rule
+    Properties:
+      Name: near05-ivs-status-rule
+      EventPattern:
+        source:
+          - aws.ivs
+        detail-type:
+          - IVS Channel State Change
+      State: ENABLED
+      Targets:
+        - Arn: !GetAtt MyApiDestination.Arn
+          Id: FastAPIWebhookTarget
+          RoleArn: !GetAtt EventBridgeRole.Arn

--- a/tests/streams/admin/test_concert_crud.py
+++ b/tests/streams/admin/test_concert_crud.py
@@ -1,10 +1,13 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from httpx import AsyncClient
 
 from app.domains.streams.admin.schemas import ConcertCreateRequest
 from app.domains.streams.admin.service import StreamAdminService
+from app.domains.streams.deps import get_admin_user
 from app.domains.streams.models import CategoryType
+from app.main import app
 
 
 @pytest.fixture
@@ -111,3 +114,65 @@ class TestConcertBasicCRUD:
                 "path/to/img.jpg"
             )
             mock_concert.delete.assert_called_once()
+
+    @pytest.mark.asyncio
+    class TestConcertRouter:
+        @pytest.fixture(autouse=True)
+        def setup_method(self, mock_user_admin):
+            # get_admin_user가 호출될 때 항상 mock_user_admin을 반환하도록 설정
+            app.dependency_overrides[get_admin_user] = lambda: mock_user_admin
+            yield
+            # 테스트 종료 후 오버라이드 제거
+            app.dependency_overrides.clear()
+
+        # 목록 조회 테스트 (Header 검증 포함)
+        async def test_list_concerts_router(self, client: AsyncClient):
+            mock_concert = MagicMock(
+                id=1,
+                title="Test",
+                category=CategoryType.KPOP,
+                description="설명",
+                thumbnail_url="https://example.com/image.jpg",
+            )
+            mock_concert.thumbnailUrl = "https://example.com/image.jpg"
+
+            mock_concerts = [mock_concert]  # 내부 속성 접근을 위해 MagicMock 사용
+
+            with patch(
+                "app.domains.streams.admin.service.StreamAdminService.list_concerts",
+                new_callable=AsyncMock,
+            ) as mock_list:
+                mock_list.return_value = (mock_concerts, "2")
+
+                response = await client.get("/api/v1/admin/concerts")
+
+                assert response.status_code == 200
+                assert response.headers["X-Next-Cursor"] == "2"
+
+        # 썸네일 업로드 테스트
+        async def test_update_thumbnail_router(self, client: AsyncClient):
+            concert_id = 1
+            file_content = b"fake image content"
+            files = {"thumbnail_file": ("test.jpg", file_content, "image/jpeg")}
+
+            returned_concert = MagicMock(
+                id=concert_id,
+                title="Test",
+                category=CategoryType.KPOP,
+                description="Description",
+                thumbnail_url="http://path/to/thumb.jpg",
+                thumbnailUrl="http://path/to/thumb.jpg",  # alias 대응
+            )
+
+            with patch(
+                "app.domains.streams.admin.service.StreamAdminService.update_concert_thumbnail",
+                new_callable=AsyncMock,
+            ) as mock_thumb:
+                mock_thumb.return_value = returned_concert
+
+                response = await client.patch(
+                    f"/api/v1/admin/concerts/{concert_id}/thumbnail",
+                    files=files,
+                )
+
+                assert response.status_code == 200

--- a/tests/streams/admin/test_get_and_update_session.py
+++ b/tests/streams/admin/test_get_and_update_session.py
@@ -52,7 +52,7 @@ async def session_with_channel(concert):
     session = await ConcertSession.create(
         concert=concert,
         session_name="1회차",
-        start_at=datetime.utcnow() + timedelta(hours=1),
+        start_at=datetime.now() + timedelta(hours=1),
         status=StreamStatus.READY,
         access_level=AccessLevel.PUBLIC,
     )

--- a/tests/streams/admin/test_ivs_webhook.py
+++ b/tests/streams/admin/test_ivs_webhook.py
@@ -1,0 +1,53 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import AsyncClient
+
+
+@pytest.mark.asyncio
+class TestIVSWebhookRouter:
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.webhook_url = "/api/v1/streams/webhook"
+        self.valid_payload = {
+            "version": "0",
+            "id": "test-id",
+            "detail-type": "IVS Stream State Change",
+            "source": "aws.ivs",
+            "time": "2024-01-01T00:00:00Z",
+            "region": "ap-northeast-2",
+            "resources": ["arn:aws:ivs:ap-northeast-2:123456789012:channel/abc"],
+            "detail": {
+                "channel_arn": "arn:aws:ivs:ap-northeast-2:123456789012:channel/abc",
+                "event_name": "Stream End",
+                "stream_id": "st-123",
+                "channel_name": "test-channel",
+            },
+        }
+
+    # API KEY가 없거나 틀렸을 때
+    async def test_ivs_webhook_invalid_key(self, client: AsyncClient):
+        # 헤더 없이 요청
+        response = await client.post(self.webhook_url, json=self.valid_payload)
+        assert response.status_code == 403
+        assert response.json()["detail"] == "Invalid API Key"
+
+        # 틀린 헤더로 요청
+        headers = {"X-API-Key": "wrong-secret-key"}
+        response = await client.post(self.webhook_url, json=self.valid_payload, headers=headers)
+        assert response.status_code == 403
+
+    # 정상 요청 시
+    async def test_ivs_webhook_success(self, client: AsyncClient):
+        from app.core.config import settings
+
+        headers = {"X-API-Key": settings.IVS_WEBHOOK_SECRET}
+
+        with patch(
+            "app.domains.streams.admin.service.StreamAdminService.handle_ivs_webhook",
+            new_callable=AsyncMock,
+        ) as mock_handle:
+            response = await client.post(self.webhook_url, json=self.valid_payload, headers=headers)
+
+            assert response.status_code == 200
+            mock_handle.assert_called_once()

--- a/tests/streams/admin/test_router.py
+++ b/tests/streams/admin/test_router.py
@@ -66,7 +66,7 @@ class TestStreamRouter:
 
                 # create concert
                 res = await client.post(
-                    "/api/v1/admin/streams/concerts",
+                    "/api/v1/admin/concerts",
                     json={
                         "title": "Test Concert",
                         "description": "Test Description",

--- a/tests/streams/admin/test_thumbnail.py
+++ b/tests/streams/admin/test_thumbnail.py
@@ -105,7 +105,7 @@ class TestStreamAdminCoverage:
             ),
         ):
             files = {"thumbnail_file": ("test.jpg", b"data", "image/jpeg")}
-            res = await client.patch("/api/v1/admin/streams/concerts/99/thumbnail", files=files)
+            res = await client.patch("/api/v1/admin/concerts/99/thumbnail", files=files)
             assert res.status_code == 200
             assert mock_concert.thumbnail_url == "new.png"
 


### PR DESCRIPTION
## ✅ PR 한줄 요약
- AWS IVS 웹훅 기반 실시간 방송 상태 동기화 및 알림 연동 구현


## 🔗 관련 이슈
- Jira: NEAR-110


## 🛠️ 변경 내용
- [x] AWS Event Bridge 구현
- [x] 보안그룹 편집 → AWS CloudFront로 접속하는 경우만 허용
- [x] CI 수정 → IVS_WEBHOOK_SECRET추가 및 카카오 더미값 깃헙 시크릿으로 변경
- [x] IVS 방송 상태 받는 라우터 추가
- [x] 스트리밍 라우터 스웨거 상 태그 세분을 위해 파일 분리

## 🧪 테스트
- [x] 로컬 테스트 완료 (`uv run pytest -q`)
- [x] ruff/mypy 통과 확인
  - [x] `uv run ruff check .`
  - [x] `uv run ruff format --check .`
  - [x] `uv run mypy .`

## ⚠️ 리뷰 포인트 / 주의사항
- 리뷰어가 특히 봐줬으면 하는 부분, 잠재적 영향 범위를 적어주세요.

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했습니다.
- [x] 불필요한 주석/로그를 제거했습니다.
- [x] 문서/설정 변경이 필요하면 반영했습니다.