### PR TITLE
[NEAR-115] Refactor: samesite=none처리

### DIFF
--- a/app/domains/auth/service.py
+++ b/app/domains/auth/service.py
@@ -90,6 +90,9 @@ class AuthService:
         response.delete_cookie(
             key="refresh_token",
             path="/",
+            samesite="none",
+            secure=True,
+            httponly=True,
         )
 
 


### PR DESCRIPTION

## ✅ PR 한줄 요약
- 프론트엔드 호환성을 위해 인증 라우트의 samesite 설정을 "none"으로 통일(쿠키삭제에서도)

## 🔗 관련 이슈
- Jira: NEAR-115

## 🛠️ 변경 내용
쿠키 삭제를 까묵다니. 나는 바보야.
