### PR TITLE
Near 119 separate concert from stream

### DIFF
--- a/app/admin/resources.py
+++ b/app/admin/resources.py
@@ -6,9 +6,9 @@ from fastadmin import register
 
 from app.admin.models import AdminUser
 from app.domains.artists.models import Artist, Follow
+from app.domains.concerts.models import Concert
 from app.domains.notifications.models import ConcertNoti
 from app.domains.streams.models import (
-    Concert,
     ConcertArtist,
     ConcertSession,
     StreamChannel,

--- a/app/api/deps.py
+++ b/app/api/deps.py
@@ -12,6 +12,7 @@ from pydantic import ValidationError
 
 from app.core.config import settings
 from app.core.security import ALGORITHM
+from app.core.utils.permissions import AdminPermission
 from app.domains.users.models import User
 
 security = HTTPBearer()
@@ -48,6 +49,15 @@ async def get_current_user(
         )
 
     return user
+
+
+async def get_admin_user(current_user: User = Depends(get_current_user)) -> User:
+    """
+    현재 로그인 어드민 유저를 반환합니다.
+    """
+    # 관리자 권한 체크
+    AdminPermission.must_be_admin(current_user)
+    return current_user
 
 
 async def get_user_from_refresh_token(refresh_token: str) -> User:

--- a/app/api/router.py
+++ b/app/api/router.py
@@ -3,10 +3,10 @@ from fastapi import APIRouter
 from app.domains.artists.router import router as artists_router
 from app.domains.auth.router import router as auth_router
 from app.domains.chat.router_ws import router as chat_router
+from app.domains.concerts.router import router as concert_admin_router
 from app.domains.notifications.router import router as notifications_router
-from app.domains.streams.admin.concert_router import router as concert_admin_router
 from app.domains.streams.admin.ivs_webhook_router import router as streams_status_router
-from app.domains.streams.admin.stream_router import router as streams_admin_router
+from app.domains.streams.admin.router import router as streams_admin_router
 from app.domains.streams.client.router import router as streams_router
 from app.domains.users.router import router as users_router
 

--- a/app/core/tortoise_config.py
+++ b/app/core/tortoise_config.py
@@ -12,6 +12,7 @@ TORTOISE_ORM = {
                 "app.domains.artists.models",
                 "app.domains.streams.models",
                 "app.domains.notifications.models",
+                "app.domains.concerts.models",
                 "aerich.models",
             ],
             "default_connection": "default",

--- a/app/core/utils/permissions.py
+++ b/app/core/utils/permissions.py
@@ -1,0 +1,10 @@
+from fastapi import HTTPException
+
+from app.domains.users.models import User
+
+
+class AdminPermission:
+    @staticmethod
+    def must_be_admin(user: User) -> None:
+        if not user.is_superuser:
+            raise HTTPException(403, "관리자만 접근이 가능합니다.")

--- a/app/domains/artists/models.py
+++ b/app/domains/artists/models.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 
 from tortoise import fields, models
 
-from app.domains.streams.models import CategoryType
+from app.domains.concerts.models import CategoryType
 
 if TYPE_CHECKING:
     from tortoise.fields import ForeignKeyRelation, ManyToManyRelation

--- a/app/domains/concerts/deps.py
+++ b/app/domains/concerts/deps.py
@@ -1,0 +1,10 @@
+from fastapi import Depends
+
+from app.domains.concerts.service import ConcertAdminService
+from app.domains.streams.deps import get_ivs_client
+from app.integrations.aws_ivs import IVSClient
+
+
+# Admin 전용 서비스 주입
+def get_concert_admin_service(ivs: IVSClient = Depends(get_ivs_client)) -> ConcertAdminService:
+    return ConcertAdminService(ivs_client=ivs)

--- a/app/domains/concerts/models.py
+++ b/app/domains/concerts/models.py
@@ -1,0 +1,48 @@
+from enum import Enum
+from typing import TYPE_CHECKING
+
+from tortoise import fields, models
+
+if TYPE_CHECKING:
+    from tortoise.fields import ForeignKeyRelation
+
+    from app.domains.streams.models import ConcertSession
+
+
+# 공연 장르 카테고리
+class CategoryType(str, Enum):
+    KPOP = "K-POP"
+    TROT = "TROT"
+    MUSICAL = "MUSICAL"
+    BAND = "BAND"
+    FAN_MEETING = "FAN_MEETING"
+    KOREA_TOUR = "KOREA_TOUR"
+
+
+class Concert(models.Model):
+    """
+    공연 메타 데이터
+    - 특정 Category에 속함
+    """
+
+    id = fields.BigIntField(primary_key=True)
+    category = fields.CharEnumField(
+        CategoryType, default=CategoryType.KPOP, db_index=True, description="장르(category)"
+    )
+    title = fields.CharField(max_length=100, description="공연 제목")
+    thumbnail_url = fields.CharField(
+        max_length=255, null=True, description="공연 썸네일 사진(포스터 등)"
+    )
+    description = fields.TextField(null=True, description="콘서트 소개 글")
+
+    created_at = fields.DatetimeField(auto_now_add=True, description="생성시각")
+    updated_at = fields.DatetimeField(auto_now=True, description="수정시각")
+
+    if TYPE_CHECKING:
+        sessions: ForeignKeyRelation["ConcertSession"]
+
+    class Meta:
+        table = "concerts"
+
+    def __str__(self) -> str:
+        return f"{self.title} (id={self.id})"

--- a/app/domains/concerts/router.py
+++ b/app/domains/concerts/router.py
@@ -10,15 +10,15 @@ from fastapi import (
     status,
 )
 
-from app.domains.streams import deps as streams_deps
-from app.domains.streams.admin.schemas import (
+from app.api.deps import get_admin_user
+from app.domains.concerts import deps as concerts_deps
+from app.domains.concerts.models import Concert
+from app.domains.concerts.schemas import (
     ConcertCreateRequest,
     ConcertDetailResponse,
     ConcertResponse,
 )
-from app.domains.streams.admin.service import StreamAdminService
-from app.domains.streams.deps import get_admin_user
-from app.domains.streams.models import Concert
+from app.domains.concerts.service import ConcertAdminService
 from app.domains.users.models import User
 
 router = APIRouter(prefix="/admin/concerts", tags=["콘서트 관리"])
@@ -35,7 +35,7 @@ router = APIRouter(prefix="/admin/concerts", tags=["콘서트 관리"])
 async def create_concert(
     data: ConcertCreateRequest,
     current_admin: User = Depends(get_admin_user),
-    service: StreamAdminService = Depends(streams_deps.get_stream_admin_service),
+    service: ConcertAdminService = Depends(concerts_deps.get_concert_admin_service),
 ) -> Concert:
     return await service.create_concert(data, current_admin)
 
@@ -50,7 +50,7 @@ async def list_concerts(
     cursor: int | None = Query(None, description="마지막으로 조회된 콘서트 ID"),
     limit: int = Query(20, ge=1, le=100),
     current_admin: User = Depends(get_admin_user),
-    service: StreamAdminService = Depends(streams_deps.get_stream_admin_service),
+    service: ConcertAdminService = Depends(concerts_deps.get_concert_admin_service),
 ) -> list[Concert]:
     concerts, next_cursor = await service.list_concerts(current_admin, limit, cursor)
 
@@ -67,7 +67,7 @@ async def list_concerts(
 async def get_concert_detail(
     concert_id: int = Path(..., description="콘서트 ID"),
     current_admin: User = Depends(get_admin_user),
-    service: StreamAdminService = Depends(streams_deps.get_stream_admin_service),
+    service: ConcertAdminService = Depends(concerts_deps.get_concert_admin_service),
 ) -> ConcertDetailResponse:
     return await service.get_concert_detail(concert_id, current_admin)
 
@@ -81,7 +81,7 @@ async def update_concert(
     concert_id: int = Path(...),
     data: ConcertCreateRequest = Body(...),
     current_admin: User = Depends(get_admin_user),
-    service: StreamAdminService = Depends(streams_deps.get_stream_admin_service),
+    service: ConcertAdminService = Depends(concerts_deps.get_concert_admin_service),
 ) -> Concert:
     return await service.update_concert(concert_id, data, current_admin)
 
@@ -94,7 +94,7 @@ async def update_concert(
 async def delete_concert(
     concert_id: int = Path(...),
     current_admin: User = Depends(get_admin_user),
-    service: StreamAdminService = Depends(streams_deps.get_stream_admin_service),
+    service: ConcertAdminService = Depends(concerts_deps.get_concert_admin_service),
 ) -> None:
     return await service.delete_concert_with_infrastructure(concert_id, current_admin)
 
@@ -109,7 +109,7 @@ async def update_concert_thumbnail(
     current_admin: User = Depends(get_admin_user),
     concert_id: int = Path(..., description="콘서트 ID"),
     thumbnail_file: UploadFile = File(..., description="썸네일 이미지 파일"),
-    service: StreamAdminService = Depends(streams_deps.get_stream_admin_service),
+    service: ConcertAdminService = Depends(concerts_deps.get_concert_admin_service),
 ) -> Concert:
     # 인증된 current_admin 객체를 서비스로 직접 전달
     return await service.update_concert_thumbnail(

--- a/app/domains/concerts/schemas.py
+++ b/app/domains/concerts/schemas.py
@@ -1,0 +1,39 @@
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+from pydantic.alias_generators import to_camel
+
+from app.domains.concerts.models import CategoryType
+from app.domains.streams.admin.schemas import SessionResponse
+
+
+class ConcertCreateRequest(BaseModel):
+    """콘서트 생성 요청 스키마"""
+
+    model_config = ConfigDict(
+        alias_generator=to_camel, populate_by_name=True, from_attributes=True, extra="forbid"
+    )  # 프론트에서 오는 camel -> snake
+    category: CategoryType
+    title: str = Field(..., min_length=1, max_length=100)
+    description: str | None = None
+    thumbnail_url: str | None = None
+
+
+class ConcertResponse(BaseModel):
+    """콘서트 생성 응답"""
+
+    model_config = ConfigDict(
+        alias_generator=to_camel, populate_by_name=True, from_attributes=True, extra="forbid"
+    )
+    id: int
+    title: str
+    category: CategoryType
+    description: str | None = None
+    thumbnail_url: str | None = Field(None)
+    created_at: datetime
+
+
+class ConcertDetailResponse(ConcertResponse):
+    """콘서트 상세 응답"""
+
+    sessions: list[SessionResponse] = Field(default_factory=list)

--- a/app/domains/concerts/service.py
+++ b/app/domains/concerts/service.py
@@ -1,0 +1,140 @@
+from typing import Any
+
+from fastapi import HTTPException, UploadFile
+
+from app.core.pagination import paginate_cursor
+from app.core.utils.image_resizer import ImageResizer
+from app.core.utils.permissions import AdminPermission
+from app.domains.concerts.models import Concert
+from app.domains.concerts.schemas import (
+    ConcertCreateRequest,
+    ConcertDetailResponse,
+)
+from app.domains.users.models import User
+from app.integrations.aws_ivs import IVSClient
+from app.integrations.aws_ivs.client import logger
+
+
+class ConcertAdminService:
+    def __init__(self, ivs_client: IVSClient):
+        self.ivs_client = ivs_client
+        self.image_resizer = ImageResizer()
+
+    async def create_concert(self, data: ConcertCreateRequest, user: User) -> Concert:
+        """
+        [Admin] 콘서트 생성
+        """
+        AdminPermission.must_be_admin(user)
+        return await Concert.create(**data.model_dump())
+
+    async def update_concert_thumbnail(
+        self, concert_id: int, file: UploadFile, user: User
+    ) -> Concert:
+        """
+        콘서트 썸네일 생성 및 수정
+        """
+        AdminPermission.must_be_admin(user)
+
+        # 콘서트 있는지 확인
+        concert = await Concert.get_or_none(id=concert_id)
+        if not concert:
+            raise HTTPException(status_code=404, detail="콘서트를 찾을 수 없습니다.")
+
+        # 기존 이미지가 있다면 S3 폴더 삭제
+        if concert.thumbnail_url:
+            await self.image_resizer.delete_all_by_id_path(concert.thumbnail_url)
+
+        # 새로운 이미지 리사이징 업로드
+        path_prefix = f"concerts/{concert.id}/thumbnail"
+        sizes = (300, 640, 1280)
+
+        urls = await self.image_resizer.upload_square_resizes(
+            image_file=file.file, sizes=sizes, path_prefix=path_prefix
+        )
+
+        # DB 업데이트
+        img_url = urls.get("640")
+        concert.thumbnail_url = img_url if img_url else ""
+        await concert.save()
+
+        return concert
+
+    async def list_concerts(
+        self, user: User, limit: int = 20, cursor: int | None = None
+    ) -> tuple[list[Concert], int | None]:
+        """
+        콘서트 목록 조회
+        """
+        AdminPermission.must_be_admin(user)
+
+        queryset = Concert.all()
+        result: Any = await paginate_cursor(queryset, limit=limit, cursor=cursor, order_by="-id")
+
+        concerts: list[Concert] = result[0]
+        next_cursor: int | None = result[1]
+
+        return concerts, next_cursor
+
+    async def get_concert_detail(self, concert_id: int, user: User) -> ConcertDetailResponse:
+        """
+        콘서트 상세 조회(하위 세션 목록 포함)
+        """
+        AdminPermission.must_be_admin(user)
+
+        concert = await Concert.get_or_none(id=concert_id).prefetch_related(
+            "sessions__stream_channel"
+        )
+
+        if not concert:
+            raise HTTPException(404, "존재하지 않는 콘서트입니다.")
+
+        return ConcertDetailResponse.model_validate(concert)
+
+    async def update_concert(
+        self, concert_id: int, data: ConcertCreateRequest, user: User
+    ) -> Concert:
+        """
+        콘서트 수정
+        """
+        AdminPermission.must_be_admin(user)
+
+        concert = await Concert.get_or_none(id=concert_id)
+        if not concert:
+            raise HTTPException(404, "수정할 콘서트를 찾을 수 없습니다.")
+
+        # 요청 데이터 반영 (exclude_unset=True로 보낸 값만 수정)
+        update_data = data.model_dump(exclude_unset=True)
+        for key, value in update_data.items():
+            setattr(concert, key, value)
+
+        await concert.save()
+        return concert
+
+    async def delete_concert_with_infrastructure(self, concert_id: int, user: User) -> None:
+        """
+        콘서트 삭제 및 AWS IVS 채널 삭제
+        """
+        AdminPermission.must_be_admin(user)
+
+        # 세션, 채널 정보 모두 가져옴
+        concert = await Concert.get_or_none(id=concert_id).prefetch_related(
+            "sessions__stream_channel"
+        )
+
+        if not concert:
+            raise HTTPException(404, "삭제할 콘서트를 찾을 수 없습니다.")
+
+        # 연결된 모든 세션의 AWS IVS 채널 먼저 삭제
+        for session in list(concert.sessions):  # type: ignore[call-overload]
+            if hasattr(session, "stream_channel") and session.stream_channel:
+                try:
+                    self.ivs_client.delete_channel(session.stream_channel.channel_arn)
+                except Exception as e:
+                    logger.warning(f"콘서트 삭제 중 세션({session.id})의 IVS 채널 삭제 실패: {e}")
+
+        # 썸네일 삭제 (S3)
+        if concert.thumbnail_url:
+            await self.image_resizer.delete_all_by_id_path(concert.thumbnail_url)
+
+        # DB 삭제(cascade)
+        await concert.delete()

--- a/app/domains/streams/admin/router.py
+++ b/app/domains/streams/admin/router.py
@@ -11,6 +11,7 @@ from fastapi import (
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 
+from app.api.deps import get_admin_user
 from app.domains.streams import deps as streams_deps
 from app.domains.streams.admin.schemas import (
     SessionCreateRequest,
@@ -19,7 +20,6 @@ from app.domains.streams.admin.schemas import (
     StreamIngestResponse,
 )
 from app.domains.streams.admin.service import StreamAdminService
-from app.domains.streams.deps import get_admin_user
 from app.domains.users.models import User
 
 router = APIRouter(prefix="/admin/streams", tags=["스트리밍 관리"])

--- a/app/domains/streams/admin/schemas.py
+++ b/app/domains/streams/admin/schemas.py
@@ -5,7 +5,6 @@ from pydantic.alias_generators import to_camel
 
 from app.domains.streams.models import (
     AccessLevel,
-    CategoryType,
     ChannelType,
     LatencyMode,
     StreamStatus,
@@ -59,16 +58,6 @@ class IVSChannelSummary(BaseModel):
 
 
 # ==================== 요청 스키마 ====================
-class ConcertCreateRequest(BaseModel):
-    """콘서트 생성 요청 스키마"""
-
-    model_config = ConfigDict(
-        alias_generator=to_camel, populate_by_name=True, from_attributes=True, extra="forbid"
-    )  # 프론트에서 오는 camel -> snake
-    category: CategoryType
-    title: str = Field(..., min_length=1, max_length=100)
-    description: str | None = None
-    thumbnail_url: str | None = None
 
 
 class SessionCreateRequest(BaseModel):
@@ -102,18 +91,6 @@ class SessionUpdateRequest(BaseModel):
 
 
 # ==================== 응답 스키마 ====================
-class ConcertResponse(BaseModel):
-    """콘서트 생성 응답"""
-
-    model_config = ConfigDict(
-        alias_generator=to_camel, populate_by_name=True, from_attributes=True, extra="forbid"
-    )
-    id: int
-    title: str
-    category: CategoryType
-    description: str | None = None
-    thumbnail_url: str | None = Field(None)
-    created_at: datetime
 
 
 class SessionResponse(BaseModel):
@@ -132,12 +109,6 @@ class SessionResponse(BaseModel):
     stream_key: str | None = Field(
         None, description="생성 시에만 일회성으로 노출되는 스트림 키", alias="value"
     )
-
-
-class ConcertDetailResponse(ConcertResponse):
-    """콘서트 상세 응답"""
-
-    sessions: list[SessionResponse] = Field(default_factory=list)
 
 
 class StreamIngestResponse(BaseModel):

--- a/app/domains/streams/admin/service.py
+++ b/app/domains/streams/admin/service.py
@@ -1,21 +1,21 @@
-from typing import Any, Literal, cast
+from typing import Literal, cast
 
 from botocore.exceptions import ClientError
-from fastapi import HTTPException, UploadFile
+from fastapi import HTTPException
 from mypy_boto3_ivs.type_defs import GetStreamResponseTypeDef
 
 from app.core.config import now_kst, settings
 from app.core.pagination import paginate_cursor
 from app.core.utils.image_resizer import ImageResizer
+from app.core.utils.permissions import AdminPermission
 from app.domains.artists.models import Artist
+from app.domains.concerts.models import Concert
 from app.domains.notifications.tasks import (
     dispatch_due_notifications,
     reschedule_session_notifications,
     schedule_session_notifications,
 )
 from app.domains.streams.admin.schemas import (
-    ConcertCreateRequest,
-    ConcertDetailResponse,
     IVSChannelSummary,
     SessionCreateRequest,
     SessionResponse,
@@ -27,14 +27,12 @@ from app.domains.streams.admin.schemas import (
 )
 from app.domains.streams.models import (
     AccessLevel,
-    Concert,
     ConcertArtist,
     ConcertSession,
     StreamChannel,
     StreamSession,
     StreamStatus,
 )
-from app.domains.streams.permissions import StreamPermission
 from app.domains.users.models import User
 from app.integrations.aws_ivs import IVSClient, IVSPlaybackProvider
 from app.integrations.aws_ivs.client import logger
@@ -45,126 +43,6 @@ class StreamAdminService:
         self.ivs_client = ivs_client
         self.playback_provider = playback_provider
         self.image_resizer = ImageResizer()
-
-    # ================================ 콘서트 관리 ====================================
-    async def create_concert(self, data: ConcertCreateRequest, user: User) -> Concert:
-        """
-        [Admin] 콘서트 생성
-        """
-        StreamPermission.must_be_admin(user)
-        return await Concert.create(**data.model_dump())
-
-    async def update_concert_thumbnail(
-        self, concert_id: int, file: UploadFile, user: User
-    ) -> Concert:
-        """
-        [Admin] 콘서트 썸네일 생성 및 수정
-        """
-        StreamPermission.must_be_admin(user)
-
-        # 콘서트 있는지 확인
-        concert = await Concert.get_or_none(id=concert_id)
-        if not concert:
-            raise HTTPException(status_code=404, detail="콘서트를 찾을 수 없습니다.")
-
-        # 기존 이미지가 있다면 S3 폴더 삭제
-        if concert.thumbnail_url:
-            await self.image_resizer.delete_all_by_id_path(concert.thumbnail_url)
-
-        # 새로운 이미지 리사이징 업로드
-        path_prefix = f"concerts/{concert.id}/thumbnail"
-        sizes = (300, 640, 1280)
-
-        urls = await self.image_resizer.upload_square_resizes(
-            image_file=file.file, sizes=sizes, path_prefix=path_prefix
-        )
-
-        # DB 업데이트
-        img_url = urls.get("640")
-        concert.thumbnail_url = img_url if img_url else ""
-        await concert.save()
-
-        return concert
-
-    async def list_concerts(
-        self, user: User, limit: int = 20, cursor: int | None = None
-    ) -> tuple[list[Concert], int | None]:
-        """
-        [Admin] 콘서트 목록 조회
-        """
-        StreamPermission.must_be_admin(user)
-
-        queryset = Concert.all()
-        result: Any = await paginate_cursor(queryset, limit=limit, cursor=cursor, order_by="-id")
-
-        concerts: list[Concert] = result[0]
-        next_cursor: int | None = result[1]
-
-        return concerts, next_cursor
-
-    async def get_concert_detail(self, concert_id: int, user: User) -> ConcertDetailResponse:
-        """
-        [Admin] 콘서트 상세 조회(하위 세션 목록 포함)
-        """
-        StreamPermission.must_be_admin(user)
-
-        concert = await Concert.get_or_none(id=concert_id).prefetch_related(
-            "sessions__stream_channel"
-        )
-
-        if not concert:
-            raise HTTPException(404, "존재하지 않는 콘서트입니다.")
-
-        return ConcertDetailResponse.model_validate(concert)
-
-    async def update_concert(
-        self, concert_id: int, data: ConcertCreateRequest, user: User
-    ) -> Concert:
-        """
-        [Admin] 콘서트 수정
-        """
-        StreamPermission.must_be_admin(user)
-
-        concert = await Concert.get_or_none(id=concert_id)
-        if not concert:
-            raise HTTPException(404, "수정할 콘서트를 찾을 수 없습니다.")
-
-        # 요청 데이터 반영 (exclude_unset=True로 보낸 값만 수정)
-        update_data = data.model_dump(exclude_unset=True)
-        for key, value in update_data.items():
-            setattr(concert, key, value)
-
-        await concert.save()
-        return concert
-
-    async def delete_concert_with_infrastructure(self, concert_id: int, user: User) -> None:
-        """
-        [Admin] 콘서트 삭제 및 AWS IVS 채널 삭제
-        """
-        StreamPermission.must_be_admin(user)
-
-        # 세션, 채널 정보 모두 가져옴
-        concert = await Concert.get_or_none(id=concert_id).prefetch_related(
-            "sessions__stream_channel"
-        )
-
-        if not concert:
-            raise HTTPException(404, "삭제할 콘서트를 찾을 수 없습니다.")
-
-        # 연결된 모든 세션의 AWS IVS 채널 먼저 삭제
-        for session in list(concert.sessions):  # type: ignore[call-overload]
-            if hasattr(session, "stream_channel") and session.stream_channel:
-                try:
-                    self.ivs_client.delete_channel(session.stream_channel.channel_arn)
-                except Exception as e:
-                    logger.warning(f"콘서트 삭제 중 세션({session.id})의 IVS 채널 삭제 실패: {e}")
-
-        # 썸네일 삭제 (S3)
-        if concert.thumbnail_url:
-            await self.image_resizer.delete_all_by_id_path(concert.thumbnail_url)
-
-        # DB 삭제(cascade)
-        await concert.delete()
 
     # ================================ IVS 상태 웹훅 ===================================
     async def handle_ivs_webhook(self, payload: StreamWebhookPayload) -> None:
@@ -221,7 +99,7 @@ class StreamAdminService:
         [Admin] 콘서트 세션 생성 및 AWS IVS 채널 자동 발급
         """
         # 권한 체크
-        StreamPermission.must_be_admin(user)
+        AdminPermission.must_be_admin(user)
 
         # Concert 있나 확인
         concert = await Concert.get(id=concert_id)
@@ -324,7 +202,7 @@ class StreamAdminService:
         """
         [Admin] 스트림 키 유출 시 재발급
         """
-        StreamPermission.must_be_admin(user)
+        AdminPermission.must_be_admin(user)
 
         session = await ConcertSession.get(id=session_id).prefetch_related("stream_channel")
         channel = session.stream_channel
@@ -348,7 +226,7 @@ class StreamAdminService:
         """
         [Admin] 세션 삭제 및 연결된 IVS 채널 영구 제거
         """
-        StreamPermission.must_be_admin(user)
+        AdminPermission.must_be_admin(user)
 
         # 채널 정보 조회를 위해 관계 로드
         session = await ConcertSession.get_or_none(id=session_id).prefetch_related("stream_channel")
@@ -370,7 +248,7 @@ class StreamAdminService:
         """
         [Admin] 라이브 방송 강제 중단 및 상태 종료 처리
         """
-        StreamPermission.must_be_admin(user)
+        AdminPermission.must_be_admin(user)
 
         session = await ConcertSession.get(id=session_id).prefetch_related("stream_channel")
         channel = session.stream_channel
@@ -395,7 +273,7 @@ class StreamAdminService:
         """
         [Admin] 라이브 방송 목록 조회
         """
-        StreamPermission.must_be_admin(user)
+        AdminPermission.must_be_admin(user)
 
         # DB 조회
         queryset = ConcertSession.all().prefetch_related("stream_channel", "concert")
@@ -459,7 +337,7 @@ class StreamAdminService:
         """
         [Admin] 콘서트 세션 상세 조회
         """
-        StreamPermission.must_be_admin(user)
+        AdminPermission.must_be_admin(user)
         session = await ConcertSession.get_or_none(id=session_id).prefetch_related("stream_channel")
         if not session:
             raise HTTPException(404, "해당 콘서트 세션을 찾을 수 없습니다.")
@@ -489,7 +367,7 @@ class StreamAdminService:
         """
         [Admin] 콘서트 세션 수정
         """
-        StreamPermission.must_be_admin(user)
+        AdminPermission.must_be_admin(user)
 
         # 동시 수정 방지 Lock
         session = (
@@ -584,7 +462,7 @@ class StreamAdminService:
         [Admin] 송출 상세 정보 조회, 실시간 상태 확인
         """
         # 관리자 권한 체크
-        StreamPermission.must_be_admin(user)
+        AdminPermission.must_be_admin(user)
 
         # DB 조회
         session = await ConcertSession.get(id=session_id).prefetch_related(

--- a/app/domains/streams/client/router.py
+++ b/app/domains/streams/client/router.py
@@ -5,6 +5,7 @@ from fastapi import APIRouter, Depends, Path
 from fastapi.params import Query
 
 from app.api import deps
+from app.domains.concerts.models import CategoryType
 from app.domains.streams import deps as streams_deps
 from app.domains.streams.client.schemas import (
     SessionDetailResponse,
@@ -12,7 +13,7 @@ from app.domains.streams.client.schemas import (
     SessionListResponse,
 )
 from app.domains.streams.client.service import StreamUserService
-from app.domains.streams.models import CategoryType, StreamStatus
+from app.domains.streams.models import StreamStatus
 from app.domains.users.models import User
 
 router = APIRouter(prefix="/streams", tags=["스트리밍"])

--- a/app/domains/streams/client/schemas.py
+++ b/app/domains/streams/client/schemas.py
@@ -3,7 +3,8 @@ from datetime import datetime
 from pydantic import BaseModel, ConfigDict
 
 from app.domains.artists.models import GroupType
-from app.domains.streams.models import CategoryType, StreamStatus
+from app.domains.concerts.models import CategoryType
+from app.domains.streams.models import StreamStatus
 
 
 class BaseSchema(BaseModel):

--- a/app/domains/streams/client/service.py
+++ b/app/domains/streams/client/service.py
@@ -7,11 +7,12 @@ from tortoise.expressions import Q
 
 from app.core.config import settings
 from app.core.pagination import paginate_cursor
+from app.domains.concerts.models import CategoryType
 from app.domains.streams.client.schemas import (
     ArtistItem,
     SessionDetailResponse,
 )
-from app.domains.streams.models import CategoryType, ConcertSession, StreamChannel, StreamStatus
+from app.domains.streams.models import ConcertSession, StreamChannel, StreamStatus
 from app.domains.streams.permissions import StreamPermission
 from app.domains.users.models import User
 from app.integrations.aws_ivs import IVSClient, IVSPlaybackProvider

--- a/app/domains/streams/deps.py
+++ b/app/domains/streams/deps.py
@@ -1,10 +1,7 @@
 from fastapi import Depends
 
-from app.api.deps import get_current_user
 from app.domains.streams.admin.service import StreamAdminService
 from app.domains.streams.client.service import StreamUserService
-from app.domains.streams.permissions import StreamPermission
-from app.domains.users.models import User
 from app.integrations.aws_ivs import IVSClient, IVSPlaybackProvider
 
 
@@ -30,10 +27,3 @@ def get_stream_user_service(
     provider: IVSPlaybackProvider = Depends(get_playback_provider),
 ) -> StreamUserService:
     return StreamUserService(ivs_client=ivs, playback_provider=provider)
-
-
-# 어드민 유저
-async def get_admin_user(current_user: User = Depends(get_current_user)) -> User:
-    # 관리자 권한 체크
-    StreamPermission.must_be_admin(current_user)
-    return current_user

--- a/app/domains/streams/models.py
+++ b/app/domains/streams/models.py
@@ -14,17 +14,8 @@ from app.core.config import settings
 
 if TYPE_CHECKING:
     from app.domains.artists.models import Artist
+    from app.domains.concerts.models import Concert
     from app.domains.notifications.models import ConcertNoti
-
-
-# 공연 장르 카테고리
-class CategoryType(str, Enum):
-    KPOP = "K-POP"
-    TROT = "TROT"
-    MUSICAL = "MUSICAL"
-    BAND = "BAND"
-    FAN_MEETING = "FAN_MEETING"
-    KOREA_TOUR = "KOREA_TOUR"
 
 
 # 방송 송출 상태
@@ -66,35 +57,6 @@ class AccessLevel(str, Enum):
     PUBLIC = "PUBLIC"  # 전체 공개
     ADMIN_ONLY = "ADMIN_ONLY"  # 관리자/테스트용
     SPECIFIC = "SPECIFIC"  # 특정 유저(결제 유저 등)
-
-
-class Concert(models.Model):
-    """
-    공연 메타 데이터
-    - 특정 Category에 속함
-    """
-
-    id = fields.BigIntField(primary_key=True)
-    category = fields.CharEnumField(
-        CategoryType, default=CategoryType.KPOP, db_index=True, description="장르(category)"
-    )
-    title = fields.CharField(max_length=100, description="공연 제목")
-    thumbnail_url = fields.CharField(
-        max_length=255, null=True, description="공연 썸네일 사진(포스터 등)"
-    )
-    description = fields.TextField(null=True, description="콘서트 소개 글")
-
-    created_at = fields.DatetimeField(auto_now_add=True, description="생성시각")
-    updated_at = fields.DatetimeField(auto_now=True, description="수정시각")
-
-    if TYPE_CHECKING:
-        sessions: ForeignKeyRelation["ConcertSession"]
-
-    class Meta:
-        table = "concerts"
-
-    def __str__(self) -> str:
-        return f"{self.title} (id={self.id})"
 
 
 class ConcertSession(models.Model):

--- a/app/domains/streams/permissions.py
+++ b/app/domains/streams/permissions.py
@@ -6,11 +6,6 @@ from app.domains.users.models import User
 
 class StreamPermission:
     @staticmethod
-    def must_be_admin(user: User) -> None:
-        if not user.is_superuser:
-            raise HTTPException(403, "관리자만 접근이 가능합니다.")
-
-    @staticmethod
     async def verify_playback_access(user: User, session: ConcertSession) -> None:
         """
         유저가 IVS 토큰을 발급받을 자격이 있는지 확인

--- a/app/domains/users/models.py
+++ b/app/domains/users/models.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 
 from tortoise import fields, models
 
-from app.domains.streams.models import CategoryType
+from app.domains.concerts.models import CategoryType
 
 if TYPE_CHECKING:
     from app.domains.artists.models import Artist

--- a/app/domains/users/schemas.py
+++ b/app/domains/users/schemas.py
@@ -5,8 +5,8 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from app.domains.artists.models import GroupType
 from app.domains.artists.schemas import ArtistBase
+from app.domains.concerts.models import CategoryType
 from app.domains.notifications.models import UserNoti
-from app.domains.streams.models import CategoryType
 from app.domains.users.models import User, UserCatFav
 
 

--- a/scripts/dev/seed_artist_kaggle.py
+++ b/scripts/dev/seed_artist_kaggle.py
@@ -11,7 +11,7 @@ from tortoise import Tortoise, run_async
 from app.core.config import settings
 from app.core.tortoise_config import TORTOISE_ORM
 from app.domains.artists.models import Artist, GroupType
-from app.domains.streams.models import CategoryType
+from app.domains.concerts.models import CategoryType
 
 """
     ** 1700+ K-Pop Idols Dataset

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@ _CONFIG = {
                 "app.domains.notifications.models",
                 "app.domains.artists.models",
                 "app.domains.streams.models",
+                "app.domains.concerts.models",
                 "aerich.models",
             ],
             "default_connection": "default",

--- a/tests/domains/artists/test_artist_router.py
+++ b/tests/domains/artists/test_artist_router.py
@@ -2,7 +2,7 @@ import pytest
 from httpx import AsyncClient
 
 from app.domains.artists.models import Artist
-from app.domains.streams.models import CategoryType
+from app.domains.concerts.models import CategoryType
 
 
 @pytest.mark.asyncio

--- a/tests/domains/artists/test_artist_service.py
+++ b/tests/domains/artists/test_artist_service.py
@@ -2,7 +2,7 @@ import pytest
 
 from app.domains.artists.models import Artist, Follow
 from app.domains.artists.service import artist_service
-from app.domains.streams.models import CategoryType
+from app.domains.concerts.models import CategoryType
 from app.domains.users.models import ProviderChoice, User
 
 

--- a/tests/notifications/test_router.py
+++ b/tests/notifications/test_router.py
@@ -4,8 +4,9 @@ from httpx import ASGITransport, AsyncClient
 
 from app.api.deps import get_current_user
 from app.core.config import now_kst
+from app.domains.concerts.models import CategoryType, Concert
 from app.domains.notifications.models import ConcertNoti, NotiKind, NotiStatus, UserNoti
-from app.domains.streams.models import CategoryType, Concert, ConcertSession
+from app.domains.streams.models import ConcertSession
 from app.domains.users.models import ProviderChoice, User
 from app.main import app
 

--- a/tests/notifications/test_service.py
+++ b/tests/notifications/test_service.py
@@ -7,6 +7,7 @@ from tortoise.exceptions import IntegrityError
 
 from app.core.config import KST, now_kst
 from app.domains.artists.models import Artist
+from app.domains.concerts.models import CategoryType, Concert
 from app.domains.notifications.models import ConcertNoti, NotiKind, NotiStatus, UserNoti
 from app.domains.notifications.service import (
     NotificationService,
@@ -14,7 +15,7 @@ from app.domains.notifications.service import (
     _build_schedule,
     _normalize_start_at,
 )
-from app.domains.streams.models import CategoryType, Concert, ConcertSession, StreamStatus
+from app.domains.streams.models import ConcertSession, StreamStatus
 from app.domains.users.models import ProviderChoice, User, UserCatFav
 
 

--- a/tests/notifications/test_tasks.py
+++ b/tests/notifications/test_tasks.py
@@ -4,9 +4,10 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from app.core.config import now_kst
+from app.domains.concerts.models import Concert
 from app.domains.notifications.models import ConcertNoti, NotiKind, NotiStatus
 from app.domains.notifications.tasks import _dispatch_due_notifications
-from app.domains.streams.models import Concert, ConcertSession, StreamStatus
+from app.domains.streams.models import ConcertSession, StreamStatus
 from app.domains.users.models import ProviderChoice, User
 
 

--- a/tests/streams/admin/test_concert_crud.py
+++ b/tests/streams/admin/test_concert_crud.py
@@ -3,17 +3,17 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from httpx import AsyncClient
 
-from app.domains.streams.admin.schemas import ConcertCreateRequest
-from app.domains.streams.admin.service import StreamAdminService
-from app.domains.streams.deps import get_admin_user
-from app.domains.streams.models import CategoryType
+from app.api.deps import get_admin_user
+from app.domains.concerts.models import CategoryType
+from app.domains.concerts.schemas import ConcertCreateRequest
+from app.domains.concerts.service import ConcertAdminService
 from app.main import app
 
 
 @pytest.fixture
-def stream_admin_service():
+def concert_admin_service():
     # IVS 클라이언트와 플레이백 프로바이더는 모킹 처리
-    service = StreamAdminService(MagicMock(), MagicMock())
+    service = ConcertAdminService(MagicMock())
     service.image_resizer = AsyncMock()
     return service
 
@@ -29,8 +29,8 @@ def mock_user_admin():
 @pytest.mark.asyncio
 class TestConcertBasicCRUD:
     @pytest.fixture(autouse=True)
-    def setup(self, stream_admin_service, mock_user_admin):
-        self.service = stream_admin_service
+    def setup(self, concert_admin_service, mock_user_admin):
+        self.service = concert_admin_service
         self.admin = mock_user_admin
 
     # 콘서트 생성 테스트
@@ -38,7 +38,7 @@ class TestConcertBasicCRUD:
         data = ConcertCreateRequest(title="테스트 콘서트", category=CategoryType.KPOP)
 
         with patch(
-            "app.domains.streams.models.Concert.create", new_callable=AsyncMock
+            "app.domains.concerts.models.Concert.create", new_callable=AsyncMock
         ) as mock_create:
             mock_create.return_value = MagicMock(id=1, title="테스트 콘서트")
 
@@ -51,7 +51,7 @@ class TestConcertBasicCRUD:
     async def test_list_concerts(self):
         mock_concerts = [MagicMock(id=1), MagicMock(id=2)]
         with patch(
-            "app.domains.streams.admin.service.paginate_cursor", new_callable=AsyncMock
+            "app.domains.concerts.service.paginate_cursor", new_callable=AsyncMock
         ) as mock_paginate:
             mock_paginate.return_value = (mock_concerts, 1)
 
@@ -68,10 +68,10 @@ class TestConcertBasicCRUD:
         mock_query = MagicMock()
         mock_query.prefetch_related.return_value = AsyncMock(return_value=mock_concert)()
 
-        with patch("app.domains.streams.models.Concert.get_or_none") as mock_get:
+        with patch("app.domains.concerts.models.Concert.get_or_none") as mock_get:
             mock_get.return_value = mock_query
 
-            with patch("app.domains.streams.admin.schemas.ConcertDetailResponse.model_validate"):
+            with patch("app.domains.concerts.schemas.ConcertDetailResponse.model_validate"):
                 await self.service.get_concert_detail(concert_id, self.admin)
 
                 mock_get.assert_called_with(id=concert_id)
@@ -85,7 +85,7 @@ class TestConcertBasicCRUD:
         mock_concert.save = AsyncMock()
 
         with patch(
-            "app.domains.streams.models.Concert.get_or_none", new_callable=AsyncMock
+            "app.domains.concerts.models.Concert.get_or_none", new_callable=AsyncMock
         ) as mock_get:
             mock_get.return_value = mock_concert
 
@@ -104,7 +104,7 @@ class TestConcertBasicCRUD:
         mock_query = MagicMock()
         mock_query.prefetch_related.return_value = AsyncMock(return_value=mock_concert)()
 
-        with patch("app.domains.streams.models.Concert.get_or_none") as mock_get:
+        with patch("app.domains.concerts.models.Concert.get_or_none") as mock_get:
             mock_get.return_value = mock_query
 
             await self.service.delete_concert_with_infrastructure(concert_id, self.admin)
@@ -139,7 +139,7 @@ class TestConcertBasicCRUD:
             mock_concerts = [mock_concert]  # 내부 속성 접근을 위해 MagicMock 사용
 
             with patch(
-                "app.domains.streams.admin.service.StreamAdminService.list_concerts",
+                "app.domains.concerts.service.ConcertAdminService.list_concerts",
                 new_callable=AsyncMock,
             ) as mock_list:
                 mock_list.return_value = (mock_concerts, "2")
@@ -165,7 +165,7 @@ class TestConcertBasicCRUD:
             )
 
             with patch(
-                "app.domains.streams.admin.service.StreamAdminService.update_concert_thumbnail",
+                "app.domains.concerts.service.ConcertAdminService.update_concert_thumbnail",
                 new_callable=AsyncMock,
             ) as mock_thumb:
                 mock_thumb.return_value = returned_concert

--- a/tests/streams/admin/test_get_and_update_session.py
+++ b/tests/streams/admin/test_get_and_update_session.py
@@ -3,13 +3,12 @@ from datetime import datetime, timedelta
 import pytest
 from fastapi import HTTPException
 
+from app.domains.concerts.models import CategoryType, Concert
 from app.domains.streams.admin.schemas import SessionUpdateRequest
 from app.domains.streams.admin.service import StreamAdminService
 from app.domains.streams.models import (
     AccessLevel,
-    CategoryType,
     ChannelType,
-    Concert,
     ConcertSession,
     LatencyMode,
     StreamChannel,

--- a/tests/streams/admin/test_router.py
+++ b/tests/streams/admin/test_router.py
@@ -4,8 +4,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from httpx import ASGITransport, AsyncClient
 
-from app.domains.streams.deps import get_admin_user
-from app.domains.streams.models import AccessLevel, ChannelType, Concert, LatencyMode, StreamStatus
+from app.api.deps import get_admin_user
+from app.domains.concerts.models import Concert
+from app.domains.streams.models import AccessLevel, ChannelType, LatencyMode, StreamStatus
 from app.main import app
 
 
@@ -46,7 +47,7 @@ class TestStreamRouter:
         try:
             with (
                 patch(
-                    "app.domains.streams.admin.service.StreamAdminService.create_concert",
+                    "app.domains.concerts.service.ConcertAdminService.create_concert",
                     new_callable=AsyncMock,
                 ) as mock_create_concert,
                 patch(

--- a/tests/streams/admin/test_service.py
+++ b/tests/streams/admin/test_service.py
@@ -61,7 +61,7 @@ class TestStreamService:
         )
 
         with (
-            patch("app.domains.streams.models.Concert.get", new_callable=AsyncMock),
+            patch("app.domains.concerts.models.Concert.get", new_callable=AsyncMock),
             patch(
                 "app.domains.streams.models.ConcertSession.create", new_callable=AsyncMock
             ) as mock_sess_create,
@@ -121,7 +121,7 @@ class TestStreamService:
         mock_user = MagicMock(is_admin=True)
 
         with (
-            patch("app.domains.streams.models.Concert.get", new_callable=AsyncMock),
+            patch("app.domains.concerts.models.Concert.get", new_callable=AsyncMock),
             patch("app.domains.streams.models.ConcertSession.create", new_callable=AsyncMock) as m,
         ):
             # session.id가 있어야 IVS 채널 명칭(session-{id}) 생성이 가능함
@@ -174,7 +174,7 @@ class TestStreamService:
         mock_session.save = AsyncMock()
 
         with (
-            patch("app.domains.streams.admin.service.StreamPermission.must_be_admin"),
+            patch("app.core.utils.permissions.AdminPermission.must_be_admin"),
             patch("app.domains.streams.models.ConcertSession.get") as mock_get,
         ):
             # get()은 즉시 mock_query를 반환 (비동기 아님)
@@ -209,7 +209,7 @@ class TestStreamService:
         mock_session.stream_channel = None
 
         with (
-            patch("app.domains.streams.admin.service.StreamPermission.must_be_admin"),
+            patch("app.core.utils.permissions.AdminPermission.must_be_admin"),
             patch("app.domains.streams.models.ConcertSession.get") as mock_get,
         ):
             mock_query = MagicMock()
@@ -232,7 +232,7 @@ class TestStreamService:
         mock_user = MagicMock(is_admin=False)  # 일반 유저
 
         with patch(
-            "app.domains.streams.admin.service.StreamPermission.must_be_admin",
+            "app.core.utils.permissions.AdminPermission.must_be_admin",
             side_effect=HTTPException(status_code=403, detail="권한 없음"),
         ):
             with pytest.raises(HTTPException) as exc:
@@ -261,7 +261,7 @@ class TestStreamService:
         mock_ivs_client.create_stream_key.return_value = {"streamKey": {"value": "new_secret_key"}}
 
         with (
-            patch("app.domains.streams.admin.service.StreamPermission.must_be_admin"),
+            patch("app.core.utils.permissions.AdminPermission.must_be_admin"),
             patch("app.domains.streams.models.ConcertSession.get") as mock_get,
         ):
             mock_query = MagicMock()
@@ -295,7 +295,7 @@ class TestStreamService:
         mock_session.delete = AsyncMock()
 
         with (
-            patch("app.domains.streams.admin.service.StreamPermission.must_be_admin"),
+            patch("app.core.utils.permissions.AdminPermission.must_be_admin"),
             patch("app.domains.streams.models.ConcertSession.get_or_none") as mock_get_none,
         ):
             mock_query = MagicMock()
@@ -325,7 +325,7 @@ class TestStreamService:
         mock_session.save = AsyncMock()
 
         with (
-            patch("app.domains.streams.admin.service.StreamPermission.must_be_admin"),
+            patch("app.core.utils.permissions.AdminPermission.must_be_admin"),
             patch("app.domains.streams.models.ConcertSession.get") as mock_get,
         ):
             mock_query = MagicMock()
@@ -357,7 +357,7 @@ class TestStreamService:
         )
 
         with (
-            patch("app.domains.streams.models.Concert.get", new_callable=AsyncMock),
+            patch("app.domains.concerts.models.Concert.get", new_callable=AsyncMock),
             patch("app.domains.streams.models.ConcertSession.create", new_callable=AsyncMock),
             patch(
                 "app.domains.streams.admin.service.Artist.filter", new_callable=AsyncMock
@@ -390,7 +390,7 @@ class TestStreamService:
         mock_session.delete = AsyncMock()
 
         with (
-            patch("app.domains.streams.admin.service.StreamPermission.must_be_admin"),
+            patch("app.core.utils.permissions.AdminPermission.must_be_admin"),
             patch("app.domains.streams.models.ConcertSession.get_or_none") as mock_get_none,
             patch("app.domains.streams.admin.service.logger") as mock_logger,
         ):
@@ -420,7 +420,7 @@ class TestStreamService:
         mock_session.save = AsyncMock()
 
         with (
-            patch("app.domains.streams.admin.service.StreamPermission.must_be_admin"),
+            patch("app.core.utils.permissions.AdminPermission.must_be_admin"),
             patch("app.domains.streams.models.ConcertSession.get") as mock_get,
             patch("app.domains.streams.admin.service.logger") as mock_logger,
         ):

--- a/tests/streams/admin/test_thumbnail.py
+++ b/tests/streams/admin/test_thumbnail.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from httpx import ASGITransport, AsyncClient
 
-from app.domains.streams.deps import get_admin_user
+from app.api.deps import get_admin_user
 from app.domains.streams.models import AccessLevel, StreamStatus
 from app.main import app
 
@@ -90,7 +90,7 @@ class TestStreamAdminCoverage:
 
         with (
             patch(
-                "app.domains.streams.models.Concert.get_or_none",
+                "app.domains.concerts.models.Concert.get_or_none",
                 new_callable=AsyncMock,
                 return_value=mock_concert,
             ),

--- a/tests/streams/client/test_service.py
+++ b/tests/streams/client/test_service.py
@@ -5,10 +5,9 @@ import pytest
 from fastapi import HTTPException
 
 from app.core.config import settings
+from app.domains.concerts.models import CategoryType, Concert
 from app.domains.streams.client.service import StreamUserService
 from app.domains.streams.models import (
-    CategoryType,
-    Concert,
     ConcertSession,
     StreamChannel,
     StreamStatus,

--- a/tests/streams/test_deps.py
+++ b/tests/streams/test_deps.py
@@ -3,32 +3,33 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastapi import HTTPException, status
 
-from app.domains.streams import deps
+from app.api import deps
+from app.domains.streams import deps as streams_deps
 from app.domains.users.models import User
 
 # --- 기초 서비스 주입 테스트 ---
 
 
 def test_get_ivs_client():
-    client = deps.get_ivs_client()
+    client = streams_deps.get_ivs_client()
     assert client is not None
     assert hasattr(client, "create_channel")
 
 
 def test_get_playback_provider():
-    provider = deps.get_playback_provider()
+    provider = streams_deps.get_playback_provider()
     assert provider is not None
     assert hasattr(provider, "sign_playback_token")
 
 
 def test_get_stream_admin_service():
-    service = deps.get_stream_admin_service()
+    service = streams_deps.get_stream_admin_service()
     assert service is not None
     assert service.ivs_client is not None
 
 
 def test_get_stream_user_service():
-    service = deps.get_stream_user_service()
+    service = streams_deps.get_stream_user_service()
     assert service is not None
     assert service.ivs_client is not None
     assert service.playback_provider is not None
@@ -44,7 +45,7 @@ async def test_get_admin_user_success():
     mock_user.is_superuser = True
 
     with patch(
-        "app.domains.streams.deps.get_current_user",
+        "app.api.deps.get_current_user",
         new_callable=AsyncMock,
     ) as mock_get_current:
         mock_get_current.return_value = mock_user

--- a/tests/streams/test_permissions.py
+++ b/tests/streams/test_permissions.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock
 import pytest
 from fastapi import HTTPException
 
+from app.core.utils.permissions import AdminPermission
 from app.domains.streams.models import AccessLevel
 from app.domains.streams.permissions import StreamPermission
 
@@ -12,12 +13,12 @@ class TestStreamPermission:
     async def test_must_be_admin(self):
         # 관리자 통과
         admin = MagicMock(is_superuser=True)
-        StreamPermission.must_be_admin(admin)
+        AdminPermission.must_be_admin(admin)
 
         # 일반인 거부
         user = MagicMock(is_superuser=False)
         with pytest.raises(HTTPException) as exc:
-            StreamPermission.must_be_admin(user)
+            AdminPermission.must_be_admin(user)
         assert exc.value.status_code == 403
 
     async def test_verify_playback_access_logic(self):

--- a/tests/users/test_service.py
+++ b/tests/users/test_service.py
@@ -7,8 +7,8 @@ from botocore.exceptions import ClientError
 from fastapi import HTTPException
 
 from app.domains.artists.models import Artist
+from app.domains.concerts.models import CategoryType
 from app.domains.notifications.models import UserNoti
-from app.domains.streams.models import CategoryType
 from app.domains.users.models import GenderChoices, ProviderChoice, User, UserCatFav, UserDeleteLog
 from app.domains.users.schemas import NotiSettings, UserMeUpdate
 from app.domains.users.service import user_service


### PR DESCRIPTION
## ✅ PR 한줄 요약
- Concert를 Stream에서 분리

## 🔗 관련 이슈
- Jira: NEAR-119

## 🛠️ 변경 내용
- [x] Concert를 Stream에서 분리 (모델, 서비스, 라우터, 스키마 전부)
- [x] 임포트 경로 수정
- [x] 어드민 관련 permission, dependency  전역으로 승격

## 🧪 테스트
- [x] 로컬 테스트 완료 (`uv run pytest -q`)
- [x] ruff/mypy 통과 확인
  - [x] `uv run ruff check .`
  - [x] `uv run ruff format --check .`
  - [x] `uv run mypy .`

## ⚠️ 리뷰 포인트 / 주의사항
- 모델 코드 분리를 해서 여기저기 건들긴 했는데 테이블이 변경된 건 없어서 마이그레이션 필요없어요

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했습니다.
- [x] 불필요한 주석/로그를 제거했습니다.
- [x] 문서/설정 변경이 필요하면 반영했습니다.