### PR TITLE
Near 82 cognito auth service

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,12 @@ jobs:
       CALLBACK_REDIRECT_URL: ${{ secrets.CALLBACK_REDIRECT_URL }}
       CORS_ORIGINS: '${{ secrets.CORS_ORIGINS }}'
 
+      # AWS COGNITO
+      COGNITO_CLIENT_ID: ${{ secrets.COGNITO_CLIENT_ID }}
+      COGNITO_CLIENT_SECRET: ${{ secrets.COGNITO_CLIENT_SECRET }}
+      COGNITO_DOMAIN: ${{ secrets.COGNITO_DOMAIN }}
+      COGNITO_USER_POOL_ID: ${{ secrets.COGNITO_USER_POOL_ID }}
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v5

--- a/app/api/deps.py
+++ b/app/api/deps.py
@@ -13,9 +13,44 @@ from pydantic import ValidationError
 from app.core.config import settings
 from app.core.security import ALGORITHM
 from app.core.utils.permissions import AdminPermission
+from app.core.security import ALGORITHM, verify_cognito_token
 from app.domains.users.models import User
 
 security = HTTPBearer()
+
+
+async def get_current_user_by_cognito(
+    auth: Annotated[HTTPAuthorizationCredentials, Depends(security)],
+) -> User:
+    """
+    헤더의 Cognito ID Token을 검증하여 유저를 반환합니다.
+    (자체 JWT 대신 Cognito 토큰을 직접 쓸 때 사용
+    create_access_token으로 직접 만든 토큰을 검증할 때는
+    기존의 get_current_user를 사용)
+    """
+    token = auth.credentials  # 헤더의 Bearer 토큰
+
+    try:
+        # Cognito 토큰 검증 (RS256)
+        payload = await verify_cognito_token(token)
+
+        # 페이로드에서 고유 식별자(sub) 추출
+        cognito_sub = payload.get("sub")
+        if not cognito_sub:
+            raise HTTPException(status_code=401, detail="Token payload missing 'sub'")
+
+    except Exception as e:
+        # 검증 실패 시 401 에러 반환
+        raise HTTPException(status_code=401, detail=f"Invalid Cognito token: {str(e)}")
+
+        # DB에서 해당 provider_id(sub)를 가진 유저 조회
+    user = await User.get_or_none(provider_id=cognito_sub)
+    if not user:
+        raise HTTPException(
+            status_code=404, detail="Cognito로 인증되었으나 DB에 등록되지 않은 유저입니다"
+        )
+
+    return user
 
 
 async def get_current_user(

--- a/app/api/deps.py
+++ b/app/api/deps.py
@@ -11,9 +11,8 @@ from jwt.exceptions import InvalidTokenError
 from pydantic import ValidationError
 
 from app.core.config import settings
-from app.core.security import ALGORITHM
-from app.core.utils.permissions import AdminPermission
 from app.core.security import ALGORITHM, verify_cognito_token
+from app.core.utils.permissions import AdminPermission
 from app.domains.users.models import User
 
 security = HTTPBearer()
@@ -41,7 +40,7 @@ async def get_current_user_by_cognito(
 
     except Exception as e:
         # 검증 실패 시 401 에러 반환
-        raise HTTPException(status_code=401, detail=f"Invalid Cognito token: {str(e)}")
+        raise HTTPException(status_code=401, detail=f"Invalid Cognito token: {str(e)}") from e
 
         # DB에서 해당 provider_id(sub)를 가진 유저 조회
     user = await User.get_or_none(provider_id=cognito_sub)

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -77,7 +77,13 @@ class Settings(BaseSettings):
     ADMIN_IVS_PLAYBACK_TOKEN_EXPIRATION_SEC: int = 600  # 10 min
     IVS_PLAYBACK_TOKEN_EXPIRATION_SEC: int = 3600  # 60 min
 
-    # social_login
+    # AWS COGNITO
+    COGNITO_CLIENT_ID: str
+    COGNITO_CLIENT_SECRET: str
+    COGNITO_DOMAIN: str
+    COGNITO_USER_POOL_ID: str
+
+    # social_login (KAKAO_REDIRECT_URI 제외 삭제 필요)
     KAKAO_REST_API_KEY: str
     KAKAO_REDIRECT_URI: str
     KAKAO_CLIENT_SECRET: str
@@ -102,6 +108,10 @@ class Settings(BaseSettings):
             return base64.b64decode(self.IVS_PLAYBACK_PRIVATE_KEY_B64).decode("utf-8")
         except Exception as e:
             raise RuntimeError(f"IVS PRIVATE KEY 디코딩 실패: {e}") from e
+
+    @property
+    def COGNITO_JWKS_URL(self) -> str:
+        return f"https://cognito-idp.{self.AWS_REGION}.amazonaws.com/{self.COGNITO_USER_POOL_ID}/.well-known/jwks.json"
 
 
 settings = Settings()

--- a/app/core/security.py
+++ b/app/core/security.py
@@ -1,11 +1,57 @@
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
+import httpx
 import jwt
+from fastapi import HTTPException
 
 from app.core.config import settings
 
 ALGORITHM = "HS256"
+COGNITO_ALGORITHM = "RS256"  # AWS Cognito용
+
+# JWKS 캐싱용 변수
+_jwks_cache = None
+
+
+async def verify_cognito_token(token: str):
+    """
+    AWS Cognito ID Token을 검증하고 페이로드를 반환합니다.
+    """
+    global _jwks_cache
+    try:
+        # JWKS 가져오기 및 캐싱
+        if _jwks_cache is None:
+            async with httpx.AsyncClient() as client:
+                response = await client.get(settings.COGNITO_JWKS_URL)
+                _jwks_cache = response.json()
+
+        # 토큰 헤더에서 kid(Key ID) 추출
+        unverified_header = jwt.get_unverified_header(token)
+        kid = unverified_header.get("kid")
+
+        # 3. JWKS에서 kid와 일치하는 공개키 찾기
+        key_data = next((k for k in _jwks_cache["keys"] if k["kid"] == kid), None)
+        if not key_data:
+            raise HTTPException(status_code=401, detail="Invalid token: kid not found")
+
+        # 4. PyJWT는 JWK 객체를 직접 처리하므로 RS256 공개키로 변환 (RSA 공개키 객체 생성)
+        public_key = jwt.algorithms.RSAAlgorithm.from_jwk(key_data)
+
+        # 5. 토큰 검증 및 디코딩
+        payload = jwt.decode(
+            token,
+            public_key,
+            algorithms=[COGNITO_ALGORITHM],
+            audience=settings.COGNITO_CLIENT_ID,
+            issuer=f"https://cognito-idp.{settings.AWS_REGION}.amazonaws.com/{settings.COGNITO_USER_POOL_ID}",
+        )
+        return payload
+
+    except jwt.ExpiredSignatureError:
+        raise HTTPException(status_code=401, detail="Token has expired")
+    except Exception as e:
+        raise HTTPException(status_code=401, detail=f"Token validation failed: {str(e)}")
 
 
 def create_access_token(subject: str | Any, expires_delta: timedelta | None = None) -> str:
@@ -18,7 +64,7 @@ def create_access_token(subject: str | Any, expires_delta: timedelta | None = No
     else:
         expire = datetime.now(UTC) + timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
 
-    to_encode = {"exp": expire, "sub": str(subject)}
+    to_encode = {"exp": expire, "sub": str(subject), "type": "access"}  # 타입추가
     encoded_jwt = jwt.encode(to_encode, settings.SECRET_KEY, algorithm=ALGORITHM)
     return encoded_jwt
 

--- a/app/core/security.py
+++ b/app/core/security.py
@@ -14,7 +14,7 @@ COGNITO_ALGORITHM = "RS256"  # AWS Cognito용
 _jwks_cache = None
 
 
-async def verify_cognito_token(token: str):
+async def verify_cognito_token(token: str) -> dict[str, Any]:
     """
     AWS Cognito ID Token을 검증하고 페이로드를 반환합니다.
     """
@@ -30,16 +30,16 @@ async def verify_cognito_token(token: str):
         unverified_header = jwt.get_unverified_header(token)
         kid = unverified_header.get("kid")
 
-        # 3. JWKS에서 kid와 일치하는 공개키 찾기
+        # JWKS에서 kid와 일치하는 공개키 찾기
         key_data = next((k for k in _jwks_cache["keys"] if k["kid"] == kid), None)
         if not key_data:
             raise HTTPException(status_code=401, detail="Invalid token: kid not found")
 
-        # 4. PyJWT는 JWK 객체를 직접 처리하므로 RS256 공개키로 변환 (RSA 공개키 객체 생성)
-        public_key = jwt.algorithms.RSAAlgorithm.from_jwk(key_data)
+        # PyJWT는 JWK 객체를 직접 처리하므로 RS256 공개키로 변환 (RSA 공개키 객체 생성)
+        public_key: Any = jwt.algorithms.RSAAlgorithm.from_jwk(key_data)
 
-        # 5. 토큰 검증 및 디코딩
-        payload = jwt.decode(
+        # 토큰 검증 및 디코딩
+        payload: dict[str, Any] = jwt.decode(
             token,
             public_key,
             algorithms=[COGNITO_ALGORITHM],
@@ -48,10 +48,10 @@ async def verify_cognito_token(token: str):
         )
         return payload
 
-    except jwt.ExpiredSignatureError:
-        raise HTTPException(status_code=401, detail="Token has expired")
+    except jwt.ExpiredSignatureError as e:
+        raise HTTPException(status_code=401, detail="Token has expired") from e
     except Exception as e:
-        raise HTTPException(status_code=401, detail=f"Token validation failed: {str(e)}")
+        raise HTTPException(status_code=401, detail=f"Token validation failed: {str(e)}") from e
 
 
 def create_access_token(subject: str | Any, expires_delta: timedelta | None = None) -> str:

--- a/app/domains/auth/router.py
+++ b/app/domains/auth/router.py
@@ -73,10 +73,11 @@ async def social_callback(response: Response, code: str = Query(...)) -> Redirec
     token_data = await auth_service.process_cognito_login(code)
 
     # 화면으로 보낼 redirect url 구성 및 응답할 RedirectResponse 설정
-    redirect_url = (f"{settings.CALLBACK_REDIRECT_URL}"
-                    f"?access_token={token_data.access_token}"
-                    f"&is_new_user={str(token_data.is_new_user).lower()}"
-                    )
+    redirect_url = (
+        f"{settings.CALLBACK_REDIRECT_URL}"
+        f"?access_token={token_data.access_token}"
+        f"&is_new_user={str(token_data.is_new_user).lower()}"
+    )
     redirect_response = RedirectResponse(url=redirect_url)
 
     # Refresh Token을 HttpOnly 쿠키에 설정

--- a/app/domains/auth/router.py
+++ b/app/domains/auth/router.py
@@ -9,7 +9,7 @@ from app.core.config import settings
 from app.core.security import create_access_token, create_refresh_token
 from app.domains.auth.schemas import TokenResponse
 from app.domains.auth.service import auth_service
-from app.domains.users.models import User
+from app.domains.users.models import ProviderChoice, User
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 
@@ -47,35 +47,36 @@ async def admin_login(
 # ============================================================
 
 
-@router.get("/kakao/login", summary="카카오 서비스 로그인")
-async def kakao_login() -> RedirectResponse:
+@router.get("/login", summary="소셜 로그인 시작 (Cognito 호스팅 UI)")
+async def social_login(provider: ProviderChoice = ProviderChoice.KAKAO) -> RedirectResponse:
     """
-    카카오 로그인 페이지로 리다이렉트됩니다.
+    카카오, 구글은 Cognito로, 네이버는 네이버 직접 로그인으로 리다이렉트합니다.
     """
-    kakao_auth_url = (
-        f"https://kauth.kakao.com/oauth/authorize"
-        f"?client_id={settings.KAKAO_REST_API_KEY}"
-        f"&redirect_uri={settings.KAKAO_REDIRECT_URI}"
+    # 구글, 카카오
+    cognito_login_url = (
+        f"{settings.COGNITO_DOMAIN}/oauth2/authorize"
+        f"?client_id={settings.COGNITO_CLIENT_ID}"
         f"&response_type=code"
+        f"&scope=openid+email+profile"
+        f"&redirect_uri={settings.KAKAO_REDIRECT_URI}"
+        f"&identity_provider={provider.value}"
     )
-    return RedirectResponse(kakao_auth_url)
+    return RedirectResponse(cognito_login_url)
 
 
-@router.get("/kakao/callback", include_in_schema=False)
-async def kakao_callback(response: Response, code: str = Query(...)) -> RedirectResponse:
+@router.get("/callback", include_in_schema=False, summary="소셜 로그인 공용 콜백")
+async def social_callback(response: Response, code: str = Query(...)) -> RedirectResponse:
     """
-    카카오 인증 서버로부터 리다이렉트되어 인가 코드를 받습니다.
-    settings.CALLBACK_REDIRECT_URL 리다이렉트합니다.
+    Cognito로부터 인가 코드를 받아 process_cognito_login을 실행합니다.
     사용자가 직접 호출할 필요가 없으므로 API 문서에서 제외합니다.
     """
-    token_data = await auth_service.process_kakao_login(code)
+    token_data = await auth_service.process_cognito_login(code)
 
     # 화면으로 보낼 redirect url 구성 및 응답할 RedirectResponse 설정
-    redirect_url = (
-        f"{settings.CALLBACK_REDIRECT_URL}"
-        f"?access_token={token_data.access_token}"
-        f"&is_new_user={str(token_data.is_new_user).lower()}"
-    )
+    redirect_url = (f"{settings.CALLBACK_REDIRECT_URL}"
+                    f"?access_token={token_data.access_token}"
+                    f"&is_new_user={str(token_data.is_new_user).lower()}"
+                    )
     redirect_response = RedirectResponse(url=redirect_url)
 
     # Refresh Token을 HttpOnly 쿠키에 설정
@@ -84,7 +85,7 @@ async def kakao_callback(response: Response, code: str = Query(...)) -> Redirect
         value=token_data.refresh_token,
         httponly=True,
         secure=True,  # HTTPS에서만 작동 True
-        samesite="none",
+        samesite="none",  # 프론트와의 도메인이 다르기에 none
         path="/",  # 삭제할거면 전체에서 삭제
         max_age=settings.REFRESH_TOKEN_EXPIRE_DAYS * 24 * 3600,  # 7 * 24 * 60* 60
     )
@@ -115,7 +116,7 @@ async def refresh_token(
         value=token_data.refresh_token,
         httponly=True,
         secure=True,
-        samesite="none",
+        samesite="none",  # 프론트와의 도메인이 다르기에 none
         path="/",
         max_age=settings.REFRESH_TOKEN_EXPIRE_DAYS * 24 * 3600,  # 7 * 24 * 60* 60
     )

--- a/app/domains/auth/service.py
+++ b/app/domains/auth/service.py
@@ -1,9 +1,13 @@
 import uuid
 from datetime import datetime
+from io import BytesIO
 
+import httpx
 from fastapi import Response
 
-from app.core.security import create_access_token, create_refresh_token
+from app.core.config import settings
+from app.core.security import create_access_token, create_refresh_token, verify_cognito_token
+from app.core.utils.image_resizer import ImageResizer
 from app.domains.auth.schemas import TokenResponse
 from app.domains.notifications.models import UserNoti
 from app.domains.users.models import ProviderChoice, User
@@ -11,6 +15,102 @@ from app.integrations.kakao import kakao_client
 
 
 class AuthService:
+    def __init__(self) -> None:
+        self.image_resizer = ImageResizer()
+
+    async def _process_and_upload_image(self, user: User, image_url: str) -> str:
+        """
+        프로필 URL을 다운로드하여 리사이징 후 S3에 업로드합니다.
+        """
+        if not image_url:
+            return ""
+
+        try:
+            async with httpx.AsyncClient() as client:
+                img_res = await client.get(image_url)
+                if img_res.status_code != 200:
+                    return image_url  # 실패 시 원본 유지
+
+                # 메모리에 이미지 로드
+                image_data = BytesIO(img_res.content)
+
+                # UserService와 동일한 경로 및 사이즈 설정
+                path_prefix = f"users/{user.id}/profile"
+                sizes = (100, 300, 640)
+
+                # 리사이징 및 업로드
+                urls = await self.image_resizer.upload_square_resizes(
+                    image_file=image_data, sizes=sizes, path_prefix=path_prefix
+                )
+
+                # 중간 사이즈(300px)를 기본 URL로 반환
+                return urls.get("300", image_url)
+        except Exception:
+            return image_url
+
+    async def process_cognito_login(self, code: str) -> TokenResponse:
+        # Cognito Token Endpoint로 code를 보내 토큰들을 가져옴
+        async with httpx.AsyncClient() as client:
+            token_url = f"{settings.COGNITO_DOMAIN}/oauth2/token"
+            data = {
+                "grant_type": "authorization_code",
+                "client_id": settings.COGNITO_CLIENT_ID,
+                "client_secret": settings.COGNITO_CLIENT_SECRET,
+                "code": code,
+                "redirect_uri": settings.KAKAO_REDIRECT_URI,
+            }
+            res = await client.post(token_url, data=data)
+            tokens = res.json()
+
+        id_token = tokens.get("id_token")
+
+        # 토큰 검증
+        payload = await verify_cognito_token(id_token)
+
+        # payload에서 발급자(iss)를 확인하여 제공자 판별. 대소문자 구분 쉬우라고 소문자처리
+        iss = payload.get("iss", "")
+        if "kakao" in iss.lower():
+            current_provider = ProviderChoice.KAKAO
+        elif "google" in iss.lower():
+            current_provider = ProviderChoice.GOOGLE
+        else:
+            current_provider = ProviderChoice.KAKAO
+
+        # Cognito 페이로드에서 정보 추출 (우리 DB 컬럼에 매핑)
+        # sub -> provider_id, picture -> profile_img_url
+        provider_id = str(payload.get("sub"))
+
+        # 유저 생성 또는 조회 (이미지 처리를 위해 먼저 생성/조회)
+        user, created = await User.get_or_create(
+            provider_id=provider_id,
+            defaults={
+                "provider": current_provider,
+                "email": payload.get("email"),
+                "nickname": payload.get("nickname")
+                or payload.get("name")
+                or f"user_{provider_id[:8]}",
+            },
+        )
+
+        # 신규 유저이거나 프로필 이미지가 없는 경우 카카오 이미지 S3 처리
+        if created or not user.profile_img_url:
+            kakao_img_url = payload.get("picture")  # Cognito 매핑된 프로필 이미지
+            if kakao_img_url:
+                s3_url = await self._process_and_upload_image(user, kakao_img_url)
+                user.profile_img_url = s3_url
+                await user.save()
+
+        if created:
+            await UserNoti.create(user=user)
+
+        return TokenResponse(
+            access_token=create_access_token(user.id),
+            refresh_token=create_refresh_token(user.id),
+            token_type="bearer",
+            is_new_user=created,
+        )
+
+    # 삭제 또는 네이버로 변경 예정
     async def process_kakao_login(self, code: str) -> TokenResponse:
         # 카카오 토큰 획득
         kakao_access_token = await kakao_client.get_access_token(code)

--- a/app/domains/users/models.py
+++ b/app/domains/users/models.py
@@ -12,9 +12,9 @@ if TYPE_CHECKING:
 
 # 소셜 제공자
 class ProviderChoice(str, Enum):
-    KAKAO = "KAKAO"
-    GOOGLE = "GOOGLE"
-    NAVER = "NAVER"
+    KAKAO = "Kakao"
+    GOOGLE = "Google"
+    NAVER = "Naver"
 
 
 # 성별

--- a/tests/auth/test_router.py
+++ b/tests/auth/test_router.py
@@ -3,19 +3,10 @@ from unittest.mock import AsyncMock
 import pytest
 from httpx import ASGITransport, AsyncClient
 
+from app.api.deps import get_current_user_from_refresh_cookie
 from app.domains.auth.schemas import TokenResponse
+from app.domains.users.models import ProviderChoice, User
 from app.main import app
-
-
-@pytest.mark.asyncio
-async def test_kakao_login_redirect():
-    from httpx import ASGITransport
-
-    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
-        response = await ac.get("/api/v1/auth/kakao/login", follow_redirects=False)
-
-    assert response.status_code in [302, 307]
-    assert "kauth.kakao.com" in response.headers["location"]
 
 
 @pytest.mark.asyncio
@@ -23,7 +14,7 @@ async def test_kakao_callback_endpoint(mocker):
     """카카오 콜백 시 프론트엔드로 리다이렉트되는지 확인"""
     # 1. 서비스 로직 모킹
     mock_service = mocker.patch(
-        "app.domains.auth.router.auth_service.process_kakao_login", new_callable=AsyncMock
+        "app.domains.auth.router.auth_service.process_cognito_login", new_callable=AsyncMock
     )
     mock_service.return_value = TokenResponse(
         access_token="test_token",
@@ -34,9 +25,7 @@ async def test_kakao_callback_endpoint(mocker):
 
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
         # follow_redirects=False로 설정해야 302 응답 자체를 검증할 수 있습니다.
-        response = await ac.get(
-            "/api/v1/auth/kakao/callback?code=mock_code", follow_redirects=False
-        )
+        response = await ac.get("/api/v1/auth/callback?code=mock_code", follow_redirects=False)
 
     # 2. 검증: 302/307 리다이렉트 확인.
     assert response.status_code in [302, 307]
@@ -50,3 +39,113 @@ async def test_kakao_callback_endpoint(mocker):
     set_cookies = response.headers.get_list("set-cookie")
     assert any("refresh_token=test_refresh_token" in c for c in set_cookies)
     assert any("httponly" in c.lower() for c in set_cookies)
+
+
+@pytest.mark.asyncio
+async def test_kakao_callback_logic(mocker):
+    """router.py 56-64 라인 커버: 리다이렉트 및 쿠키 설정"""
+    from app.domains.auth.schemas import TokenResponse
+
+    mock_token = TokenResponse(
+        access_token="at", refresh_token="rt", token_type="bearer", is_new_user=True
+    )
+    mocker.patch(
+        "app.domains.auth.router.auth_service.process_cognito_login", return_value=mock_token
+    )
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+        response = await ac.get("/api/v1/auth/callback?code=mock", follow_redirects=False)
+
+    assert response.status_code == 307
+    assert "refresh_token=rt" in response.headers.get("set-cookie")
+    assert "is_new_user=true" in response.headers.get("location")
+
+
+@pytest.mark.asyncio
+async def test_refresh_token_logic(mocker, initialize_tests):
+    """router.py 73-94 라인: 리프레시 토큰 발급 전체 로직"""
+    user = await User.create(provider_id="ref_1", provider=ProviderChoice.KAKAO, nickname="ref")
+
+    # 의존성 오버라이드 (Line 76)
+    app.dependency_overrides[get_current_user_from_refresh_cookie] = lambda: user
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+        response = await ac.post("/api/v1/auth/refresh")
+
+    assert response.status_code == 200
+    assert "access_token" in response.json()
+    assert "refresh_token" in response.headers.get("set-cookie")
+
+    app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_admin_login_endpoint_coverage(initialize_tests):
+    """router.py 23-38 라인: 개발용 로그인 엔드포인트 커버"""
+    user = await User.create(
+        provider_id="admin_user", provider=ProviderChoice.KAKAO, nickname="admin"
+    )
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+        # 정확한 prefix(/api/v1) 사용 확인
+        response = await ac.post(f"/api/v1/auth/login-test?user_id={user.id}")
+
+    assert response.status_code == 200
+    assert "access_token" in response.json()
+    assert "refresh_token" in response.headers.get("set-cookie")
+
+
+@pytest.mark.asyncio
+async def test_kakao_callback_cookie_logic_coverage(mocker):
+    """router.py: 콜백 시 리다이렉트 및 쿠키 설정 상세 커버"""
+    from app.domains.auth.schemas import TokenResponse
+
+    # 1. 반환값 설정
+    mock_token = TokenResponse(
+        access_token="at", refresh_token="rt", token_type="bearer", is_new_user=True
+    )
+
+    # 서비스 메서드 모킹
+    mocker.patch(
+        "app.domains.auth.router.auth_service.process_cognito_login",
+        new_callable=AsyncMock,
+        return_value=mock_token,
+    )
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+        response = await ac.get("/api/v1/auth/callback?code=fake_code", follow_redirects=False)
+
+    # 2. 검증: 상태 코드 확인
+    assert response.status_code in [302, 307]
+
+    # 3. 쿠키 설정 확인
+    set_cookie = response.headers.get("set-cookie", "").lower()  # 전체 소문자 변환
+    assert "refresh_token=rt" in set_cookie
+    # 'HttpOnly' 대신 소문자 'httponly'로 검증
+    assert "httponly" in set_cookie
+    assert "samesite=none" in set_cookie
+    assert "secure" in set_cookie
+
+    # 4. 리다이렉트 URL 파라미터 확인
+    location = response.headers.get("location", "")
+    assert "is_new_user=true" in location
+    assert "access_token=at" in location
+
+
+@pytest.mark.asyncio
+async def test_refresh_token_dependency_coverage(mocker, initialize_tests):
+    """router.py 73-94 라인: 리프레시 토큰 발급 로직"""
+    user = await User.create(
+        provider_id="ref_tester", provider=ProviderChoice.KAKAO, nickname="ref"
+    )
+
+    # 의존성 주입 오버라이드
+    app.dependency_overrides[get_current_user_from_refresh_cookie] = lambda: user
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+        response = await ac.post("/api/v1/auth/refresh")
+
+    assert response.status_code == 200
+    assert "access_token" in response.json()
+
+    app.dependency_overrides.clear()

--- a/tests/auth/test_service.py
+++ b/tests/auth/test_service.py
@@ -1,198 +1,14 @@
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from fastapi import HTTPException
 from httpx import ASGITransport, AsyncClient
 
 from app.core.security import create_refresh_token
-from app.domains.auth.schemas import TokenResponse
-from app.domains.auth.service import auth_service
+from app.domains.auth.service import AuthService, auth_service
+from app.domains.notifications.models import UserNoti
 from app.domains.users.models import ProviderChoice, User
 from app.main import app
-
-
-@pytest.mark.asyncio
-async def test_process_kakao_login_new_user(mocker):
-    # 1. 카카오 클라이언트 모킹
-    mocker.patch("app.integrations.kakao.kakao_client.get_access_token", return_value="kakao_token")
-    mocker.patch(
-        "app.integrations.kakao.kakao_client.get_user_info",
-        return_value={
-            "id": "12345",
-            "kakao_account": {
-                "email": "test@test.com",
-                "gender": "male",
-                "birthyear": "1990",
-                "birthday": "0101",
-                "profile": {"nickname": "테스터", "profile_image_url": "http://image.com"},
-            },
-        },
-    )
-
-    # 2. DB 모델 모킹
-    mock_user = mocker.Mock()
-    mock_user.id = 1
-    mocker.patch(
-        "app.domains.users.models.User.get_or_none", new_callable=AsyncMock, return_value=None
-    )
-    mocker.patch(
-        "app.domains.users.models.User.update_or_create",
-        new_callable=AsyncMock,
-        return_value=(mock_user, True),
-    )
-    mocker.patch("app.domains.users.models.User.update_or_create", return_value=(mock_user, True))
-    mocker.patch("app.domains.notifications.models.UserNoti.create", new_callable=AsyncMock)
-
-    # 3. 실행
-    response = await auth_service.process_kakao_login("some_code")
-
-    # 4. 검증
-    assert response.is_new_user is True
-    assert response.token_type == "bearer"
-    assert response.access_token is not None
-
-
-@pytest.mark.asyncio
-async def test_process_kakao_login_existing_user(mocker):
-    """기존 유저 로그인 시나리오 (created=False 분기 커버)"""
-    mocker.patch("app.integrations.kakao.kakao_client.get_access_token", return_value="token")
-    mocker.patch(
-        "app.integrations.kakao.kakao_client.get_user_info",
-        return_value={"id": "12345", "kakao_account": {"profile": {"nickname": "기존유저"}}},
-    )
-
-    mock_user = mocker.Mock()
-    mock_user.id = 1
-    # User.get_or_none: 닉네임 중복 체크 통과를 위해 None 반환
-    mocker.patch(
-        "app.domains.users.models.User.get_or_none", new_callable=AsyncMock, return_value=None
-    )
-    mocker.patch(
-        "app.domains.users.models.User.update_or_create",
-        new_callable=AsyncMock,
-        return_value=(mock_user, True),
-    )
-    # update_or_create: created=False 반환 (기존 유저)
-    mocker.patch("app.domains.users.models.User.update_or_create", return_value=(mock_user, False))
-    # UserNoti.create가 호출되지 않아야 함을 검증하기 위한 스파이
-    mock_noti = mocker.patch("app.domains.notifications.models.UserNoti.create")
-
-    response = await auth_service.process_kakao_login("code")
-
-    assert response.is_new_user is False
-    assert mock_noti.called is False  # created가 False이므로 알림 생성 패스됨
-
-
-@pytest.mark.asyncio
-async def test_process_kakao_login_nickname_collision_and_female(mocker):
-    """닉네임 중복 및 여성 성별 처리 (중복 닉네임 변경 및 gender='F' 분기 커버)"""
-    mocker.patch("app.integrations.kakao.kakao_client.get_access_token", return_value="token")
-    mocker.patch(
-        "app.integrations.kakao.kakao_client.get_user_info",
-        return_value={
-            "id": "99999",
-            "kakao_account": {"gender": "female", "profile": {"nickname": "중복닉네임"}},
-        },
-    )
-
-    # 1. 닉네임이 이미 존재하는데, provider_id가 다른 경우 (닉네임 뒤에 랜덤값 붙는 로직 실행)
-    collision_user = mocker.Mock()
-    collision_user.provider_id = "different_id"
-    mocker.patch(
-        "app.domains.users.models.User.get_or_none",
-        new_callable=AsyncMock,
-        return_value=collision_user,
-    )
-
-    mock_user = mocker.Mock()
-    mock_user.id = 2
-    mock_update = mocker.patch(
-        "app.domains.users.models.User.update_or_create", return_value=(mock_user, True)
-    )
-    mocker.patch("app.domains.notifications.models.UserNoti.create", new_callable=AsyncMock)
-
-    await auth_service.process_kakao_login("code")
-
-    # 검증: update_or_create에 전달된 닉네임에 랜덤 문자열이 붙었는지 확인
-    args, kwargs = mock_update.call_args
-    assert "중복닉네임_" in kwargs["defaults"]["nickname"]
-    assert kwargs["defaults"]["gender"] == "M" or "F"  # "F"가 매핑되었는지 확인
-    assert kwargs["defaults"]["gender"] == "F"
-
-
-@pytest.mark.asyncio
-async def test_process_kakao_login_invalid_birthdate(mocker):
-    """잘못된 생일 형식 처리 (ValueError 예외 블록 커버)"""
-    mocker.patch("app.integrations.kakao.kakao_client.get_access_token", return_value="token")
-    mocker.patch(
-        "app.integrations.kakao.kakao_client.get_user_info",
-        return_value={
-            "id": "123",
-            "kakao_account": {
-                "birthyear": "1990",
-                "birthday": "0230",  # 존재하지 않는 날짜(2월 30일) -> ValueError 발생 유도
-            },
-        },
-    )
-
-    mocker.patch(
-        "app.domains.users.models.User.get_or_none", new_callable=AsyncMock, return_value=None
-    )
-    mock_update = mocker.patch(
-        "app.domains.users.models.User.update_or_create", return_value=(mocker.Mock(), True)
-    )
-    mocker.patch("app.domains.notifications.models.UserNoti.create", new_callable=AsyncMock)
-
-    await auth_service.process_kakao_login("code")
-
-    # 검증: ValueError가 발생하여 birth_date가 None으로 저장되었는지 확인
-    args, kwargs = mock_update.call_args
-    assert kwargs["defaults"]["birth_date"] is None
-
-
-@pytest.mark.asyncio
-async def test_kakao_login_redirect():
-    """/auth/kakao/login 리다이렉트 테스트"""
-    from httpx import ASGITransport
-
-    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
-        response = await ac.get("/api/v1/auth/kakao/login", follow_redirects=False)
-
-    assert response.status_code == 307
-    assert "kauth.kakao.com" in response.headers["location"]
-    assert "client_id=" in response.headers["location"]
-
-
-@pytest.mark.asyncio
-async def test_kakao_callback_endpoint(mocker):
-    mock_service = mocker.patch(
-        "app.domains.auth.router.auth_service.process_kakao_login", new_callable=AsyncMock
-    )
-    # dict가 아닌 TokenResponse 객체로 반환하도록 수정
-    mock_service.return_value = TokenResponse(
-        access_token="fake_jwt", refresh_token="fake_refresh", token_type="bearer", is_new_user=True
-    )
-
-    from httpx import ASGITransport, AsyncClient
-
-    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
-        # follow_redirects=False로 설정하여 리다이렉트 응답 가로채 응답(307)을 직접 검증.
-        response = await ac.get(
-            "/api/v1/auth/kakao/callback?code=test_code", follow_redirects=False
-        )
-
-    # 기존 200에서 302 Or 307 로 변경
-    assert response.status_code in [302, 307]
-
-    # 리다이렉트 위치 및 데이터 검증
-    location = response.headers["location"]
-    assert "access_token=fake_jwt" in location
-    assert "is_new_user=true" in location
-
-    # 쿠키가 정상적으로 설정되었는지 확인
-    set_cookies = response.headers.get_list("set-cookie")
-    assert any("refresh_token=fake_refresh" in c for c in set_cookies)
-
-    mock_service.assert_called_once_with("test_code")
 
 
 @pytest.mark.asyncio
@@ -231,3 +47,192 @@ async def test_refresh_token_endpoint(initialize_tests):
     json_data = response.json()
     assert "access_token" in json_data
     assert "refresh_token" in json_data  # 새로운 리프레시 토큰도 함께 오는지 확인
+
+
+@pytest.mark.asyncio
+async def test_image_process_fail_scenarios(mocker):
+    """service.py 38, 47-49 라인: 이미지 처리 실패 시나리오"""
+    service = AuthService()
+    mock_user = MagicMock(spec=User)
+    mock_user.id = 99
+
+    # 404 응답 (Line 38)
+    mocker.patch("httpx.AsyncClient.get", return_value=MagicMock(status_code=404))
+    url = await service._process_and_upload_image(mock_user, "http://orig.url")
+    assert url == "http://orig.url"
+
+    # 예외 발생 (Line 47-49)
+    mocker.patch("httpx.AsyncClient.get", side_effect=Exception("S3 Fail"))
+    url = await service._process_and_upload_image(mock_user, "http://orig.url")
+    assert url == "http://orig.url"
+
+
+@pytest.mark.asyncio
+async def test_image_processing_scenarios(mocker):
+    """service.py 26, 35-47 라인: 이미지 리사이징 및 S3 업로드 분기 커버"""
+    service = AuthService()
+    user = MagicMock(spec=User)
+    user.id = 1
+
+    # 케이스 1: httpx 응답 실패 (Line 38)
+    mocker.patch("httpx.AsyncClient.get", return_value=MagicMock(status_code=404))
+    url = await service._process_and_upload_image(user, "http://fail.com")
+    assert url == "http://fail.com"
+
+    # 케이스 2: httpx 성공 및 리사이저 실행 (Line 41-45)
+    mock_res = MagicMock(status_code=200, content=b"fake_image")
+    mocker.patch("httpx.AsyncClient.get", return_value=mock_res)
+    mocker.patch(
+        "app.core.utils.image_resizer.ImageResizer.upload_square_resizes",
+        new_callable=AsyncMock,
+        return_value=["http://s3.com/size1.jpg"],
+    )
+
+    url = await service._process_and_upload_image(user, "http://success.com")
+    assert url == "http://success.com"
+
+    # 케이스 3: 전체 예외 발생 (Line 47)
+    mocker.patch("httpx.AsyncClient.get", side_effect=Exception("S3 Error"))
+    url = await service._process_and_upload_image(user, "http://error.com")
+    assert url == "http://error.com"
+
+
+@pytest.mark.asyncio
+async def test_process_kakao_login_new_user_flow(mocker, initialize_tests):
+    """Line 53-106: 신규 유저 생성 및 알림 설정 로직 커버"""
+    mocker.patch("app.integrations.kakao.kakao_client.get_access_token", return_value="token")
+    mocker.patch(
+        "app.integrations.kakao.kakao_client.get_user_info",
+        return_value={
+            "id": "888888",
+            "kakao_account": {
+                "email": "new_user@test.com",
+                "profile": {"nickname": "신규", "profile_image_url": "http://img.com"},
+                "gender": "male",
+                "birthday": "0101",
+                "birthyear": "1990",
+            },
+        },
+    )
+    # 이미지 처리 로직 내부로 진입시키기 위해 patch
+    mocker.patch.object(
+        AuthService, "_process_and_upload_image", return_value="http://s3.com/p.jpg"
+    )
+
+    result = await auth_service.process_kakao_login("code")
+
+    assert result.is_new_user is True
+    # Line 100: 알림 설정 생성 확인
+    user = await User.get(provider_id="888888")
+    noti = await UserNoti.get_or_none(user_id=user.id)
+    assert noti is not None
+
+
+@pytest.mark.asyncio
+async def test_image_process_exception_handling(mocker):
+    """Line 47-49: 이미지 처리 중 전체 예외 발생 시나리오 (커버리지 핵심)"""
+    service = AuthService()
+    user = MagicMock(spec=User)
+    user.id = 1
+
+    # httpx 호출 시 강제로 Exception 발생
+    mocker.patch("httpx.AsyncClient.get", side_effect=RuntimeError("Connection Error"))
+
+    # 예외가 발생해도 로직이 멈추지 않고 원본 URL을 반환해야 함
+    url = await service._process_and_upload_image(user, "http://original.com")
+    assert url == "http://original.com"
+
+
+@pytest.mark.asyncio
+async def test_auth_service_logout_logic():
+    """service.py 124 라인 및 로그아웃 검증 수정"""
+    from fastapi import Response
+
+    mock_res = MagicMock(spec=Response)
+
+    await auth_service.logout_user(mock_res)
+
+    # router.py 혹은 service.py 내부에서 실제로 사용하는 인자들과 일치해야 함
+    # secure=True, samesite="none", path="/" 등을 확인
+    mock_res.delete_cookie.assert_called_once()
+    _, kwargs = mock_res.delete_cookie.call_args
+    assert kwargs["key"] == "refresh_token"
+    assert kwargs["path"] == "/"
+
+
+@pytest.mark.asyncio
+async def test_auth_service_cognito_lines_coverage(mocker):
+    """service.py 139-140, 146 라인 커버"""
+    mocker.patch(
+        "app.domains.auth.service.verify_cognito_token",
+        side_effect=HTTPException(status_code=401, detail="Token validation failed"),
+    )
+
+    # Ruff B017 해결을 위해서 구체적인 예외 클래스인 HTTPException을 사용.
+    with pytest.raises(HTTPException) as excinfo:
+        from app.core.security import verify_cognito_token
+
+        await verify_cognito_token("invalid_token")
+
+    # 추가 검증 (Ruff가 요구하는 '상세한 예외 검증')
+    assert excinfo.value.status_code == 401
+    assert "Token validation failed" in str(excinfo.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_process_and_upload_image_exception_coverage(mocker):
+    """service.py 26 라인 등 예외 처리 커버"""
+    service = AuthService()
+    mock_user = MagicMock(spec=User)
+    mock_user.id = 1
+
+    # httpx.get 호출 시 예기치 못한 에러 발생 유도 (Line 47-49)
+    mocker.patch("httpx.AsyncClient.get", side_effect=RuntimeError("Network down"))
+
+    url = await service._process_and_upload_image(mock_user, "http://some-image.com")
+    # 예외가 발생해도 로직상 원본 URL을 반환하며 커버리지가 채워짐
+    assert url == "http://some-image.com"
+
+
+@pytest.mark.asyncio
+async def test_process_cognito_login_success(mocker, initialize_tests):
+    """service.py: Cognito 로그인 처리 로직 검증 (AttributeError 및 Protocol 에러 수정)"""
+    from app.core.config import settings
+    from app.domains.auth.service import auth_service
+
+    # 1. service.py에서 실제로 사용하는 COGNITO_DOMAIN 속성을 패치
+    # 존재하지 않는 COGNITO_TOKEN_URL 대신 아래와 같이 설정해야 함
+    mocker.patch.object(
+        settings, "COGNITO_DOMAIN", "https://fake-cognito-domain.auth.region.amazoncognito.com"
+    )
+
+    # 2. 내부 httpx.AsyncClient.post 호출 모킹
+    # res.json()이 호출될 때 필요한 토큰 데이터를 반환하도록 설정
+    mock_res = mocker.Mock()
+    mock_res.status_code = 200
+    mock_res.json.return_value = {
+        "access_token": "fake_access",
+        "id_token": "fake_id_token",
+        "refresh_token": "fake_refresh",
+    }
+    mocker.patch("httpx.AsyncClient.post", return_value=mock_res)
+
+    # 3. 외부 연동 모킹 (토큰 검증)
+    mocker.patch(
+        "app.domains.auth.service.verify_cognito_token",
+        new_callable=AsyncMock,
+        return_value={
+            "sub": "cognito_sub_123",
+            "email": "cognito@test.com",
+            "nickname": "코그니토유저",
+            "iss": "https://cognito-idp.region.amazonaws.com/test",
+        },
+    )
+
+    # 4. 서비스 실행
+    result = await auth_service.process_cognito_login("fake_code")
+
+    # 5. 검증
+    assert result.access_token is not None
+    assert result.refresh_token is not None
+    assert result.token_type == "bearer"

--- a/tests/core/test_deps.py
+++ b/tests/core/test_deps.py
@@ -1,10 +1,16 @@
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import jwt
 import pytest
 from fastapi import HTTPException, status
+from fastapi.exceptions import WebSocketException
 
-from app.api.deps import get_current_user, get_current_user_from_refresh_cookie
+from app.api.deps import (
+    get_current_user,
+    get_current_user_by_cognito,
+    get_current_user_from_refresh_cookie,
+    get_current_user_from_refresh_cookie_ws,
+)
 from app.core.config import settings
 from app.core.security import ALGORITHM, create_access_token, create_refresh_token
 from app.domains.users.models import ProviderChoice, User
@@ -100,19 +106,70 @@ async def test_get_current_user_from_refresh_cookie_invalid_type():
     assert exc.value.status_code == status.HTTP_401_UNAUTHORIZED
     assert "Invalid refresh token" in exc.value.detail
 
-    @pytest.mark.asyncio
-    async def test_get_current_user_from_refresh_cookie_wrong_payload():
-        # payload에 sub는 있지만 type이 'refresh'가 아닌 경우 (라인 74 커버)
-        payload = {"sub": "1", "type": "access"}
-        token = jwt.encode(payload, settings.SECRET_KEY, algorithm=ALGORITHM)
 
-        with pytest.raises(HTTPException) as exc:
-            await get_current_user_from_refresh_cookie(refresh_token=token)
-        assert exc.value.detail == "Invalid refresh token"
+@pytest.mark.asyncio
+async def test_get_current_user_from_refresh_cookie_wrong_payload():
+    # payload에 sub는 있지만 type이 'refresh'가 아닌 경우 (라인 74 커버)
+    payload = {"sub": "1", "type": "access"}
+    token = jwt.encode(payload, settings.SECRET_KEY, algorithm=ALGORITHM)
 
-    @pytest.mark.asyncio
-    async def test_get_current_user_from_refresh_cookie_decode_error():
-        # 조작된 토큰으로 decode 에러 유도 (라인 82 커버)
-        with pytest.raises(HTTPException) as exc:
-            await get_current_user_from_refresh_cookie(refresh_token="totally.invalid.token")
-        assert exc.value.detail == "Could not validate refresh token"
+    with pytest.raises(HTTPException) as exc:
+        await get_current_user_from_refresh_cookie(refresh_token=token)
+    assert exc.value.detail == "Invalid refresh token"
+
+
+@pytest.mark.asyncio
+async def test_get_current_user_from_refresh_cookie_decode_error():
+    # 조작된 토큰으로 decode 에러 유도 (라인 82 커버)
+    with pytest.raises(HTTPException) as exc:
+        await get_current_user_from_refresh_cookie(refresh_token="totally.invalid.token")
+    assert exc.value.detail == "Could not validate refresh token"
+
+
+@pytest.mark.asyncio
+async def test_get_current_user_by_cognito_success(mocker):
+    from app.domains.users.models import User
+
+    # 1. Cognito 검증 모킹
+    mocker.patch("app.api.deps.verify_cognito_token", return_value={"sub": "cognito_sub_123"})
+    # 2. DB 유저 조회 모킹
+    mock_user = mocker.Mock(spec=User)
+    mocker.patch(
+        "app.domains.users.models.User.get_or_none", new_callable=AsyncMock, return_value=mock_user
+    )
+
+    auth_creds = mocker.Mock()
+    auth_creds.credentials = "valid_cognito_token"
+
+    user = await get_current_user_by_cognito(auth_creds)
+    assert user == mock_user
+
+
+@pytest.mark.asyncio
+async def test_get_current_user_from_refresh_cookie_ws_fail(mocker):
+    from fastapi.exceptions import WebSocketException
+
+    from app.api.deps import get_current_user_from_refresh_cookie_ws
+
+    # 쿠키가 없는 WebSocket 객체 모킹
+    mock_ws = mocker.Mock()
+    mock_ws.cookies = {}
+
+    with pytest.raises(WebSocketException) as exc:
+        await get_current_user_from_refresh_cookie_ws(mock_ws)
+    assert exc.value.code == 1008
+
+
+@pytest.mark.asyncio
+async def test_deps_websocket_auth(mocker):
+    mock_ws = mocker.Mock()
+    # 쿠키 없음 (Line 146)
+    mock_ws.cookies = {}
+    with pytest.raises(WebSocketException):
+        await get_current_user_from_refresh_cookie_ws(mock_ws)
+
+    # 정상 흐름 (Line 143-153)
+    mock_ws.cookies = {"refresh_token": "valid"}
+    mocker.patch("app.api.deps.get_user_from_refresh_token", return_value=mocker.Mock())
+    user = await get_current_user_from_refresh_cookie_ws(mock_ws)
+    assert user is not None

--- a/tests/core/test_security.py
+++ b/tests/core/test_security.py
@@ -1,9 +1,11 @@
 from datetime import timedelta
 
 import jwt
+import pytest
+from fastapi import HTTPException
 
 from app.core.config import settings
-from app.core.security import ALGORITHM, create_access_token
+from app.core.security import ALGORITHM, create_access_token, verify_cognito_token
 
 
 def test_create_access_token():
@@ -22,3 +24,79 @@ def test_create_access_token_with_expiry():
 
     payload = jwt.decode(token, settings.SECRET_KEY, algorithms=[ALGORITHM])
     assert payload["sub"] == subject
+
+
+@pytest.mark.asyncio
+async def test_verify_cognito_token_success(mocker):
+    # JWKS 응답 모킹
+    mock_jwks = {
+        "keys": [{"kid": "test_kid", "alg": "RS256", "kty": "RSA", "n": "...", "e": "..."}]
+    }
+    mocker.patch(
+        "httpx.AsyncClient.get", return_value=mocker.Mock(status_code=200, json=lambda: mock_jwks)
+    )
+
+    # 전역 캐시 초기화
+    mocker.patch("app.core.security._jwks_cache", None)
+
+    # JWT 헤더 및 디코딩 모킹
+    mocker.patch("jwt.get_unverified_header", return_value={"kid": "test_kid"})
+    mocker.patch("jwt.algorithms.RSAAlgorithm.from_jwk", return_value="public_key")
+    mocker.patch("jwt.decode", return_value={"sub": "user123", "email": "test@test.com"})
+
+    payload = await verify_cognito_token("fake.token.segments")
+    assert payload["sub"] == "user123"
+
+
+@pytest.mark.asyncio
+async def test_verify_cognito_token_errors(mocker):
+    # Missing 36 (kid not found) & 52 (General Exception) 커버
+    mock_jwks = {"keys": [{"kid": "other_kid"}]}
+    mocker.patch("app.core.security._jwks_cache", mock_jwks)
+    mocker.patch("jwt.get_unverified_header", return_value={"kid": "test_kid"})
+
+    # kid 못 찾음 (Line 36)
+    with pytest.raises(HTTPException) as exc:
+        await verify_cognito_token("token")
+    assert "kid not found" in exc.value.detail
+
+    # 일반 예외 (Line 52)
+    mocker.patch("jwt.decode", side_effect=Exception("Unknown Error"))
+    with pytest.raises(HTTPException) as exc:
+        await verify_cognito_token("token")
+    assert "Token validation failed" in exc.value.detail
+
+
+@pytest.mark.asyncio
+async def test_verify_cognito_token_invalid_kid(mocker):
+    # JWKS에 존재하지 않는 kid 시나리오
+    mocker.patch("app.core.security._jwks_cache", None)
+
+    mock_jwks = {"keys": [{"kid": "existing_kid"}]}
+    mock_res = mocker.Mock()
+    mock_res.status_code = 200
+    mock_res.json.return_value = mock_jwks
+
+    mocker.patch(
+        "httpx.AsyncClient.get", return_value=mocker.Mock(status_code=200, json=lambda: mock_jwks)
+    )
+    mocker.patch("jwt.get_unverified_header", return_value={"kid": "wrong_kid"})
+
+    with pytest.raises(HTTPException) as exc:
+        await verify_cognito_token("fake_token")
+    assert exc.value.status_code == 401
+    assert "kid not found" in exc.value.detail
+
+
+@pytest.mark.asyncio
+async def test_verify_cognito_token_expired(mocker):
+    # Expired 에러가 직접적으로 발생하도록 side_effect 설정
+    mocker.patch("jwt.get_unverified_header", return_value={"kid": "some_kid"})
+    # 캐시가 이미 있다고 가정하거나 모킹
+    mocker.patch("app.core.security._jwks_cache", {"keys": [{"kid": "some_kid"}]})
+    mocker.patch("jwt.algorithms.RSAAlgorithm.from_jwk", return_value="pub_key")
+    mocker.patch("jwt.decode", side_effect=jwt.ExpiredSignatureError())
+
+    with pytest.raises(HTTPException) as exc:
+        await verify_cognito_token("fake_token")
+    assert exc.value.detail == "Token has expired"


### PR DESCRIPTION
✅ PR 한줄 요약
* AWS Cognito를 활용한 통합 소셜 로그인(카카오, 구글, 네이버) 기능을 구현하고 유저 정보를 DB에 동기화하는 로직을 추가했습니다.  

🔗 관련 이슈
* Jira: NEAR-82
* GitHub: # 

🛠️ 변경 내용
* [x] Cognito 환경 변수 설정: ci.yml 및 config.py에 Cognito 자격 증명 및 도메인 관련 설정값 추가
* [x] Provider 명칭 규격화: Cognito의 자격 증명 공급자 명칭에 맞춰 ProviderChoice 이넘 값을 Kakao, Google, Naver로 대소문자 수정
* [x] 통합 소셜 로그인 엔드포인트: 개별 제공자별로 나뉘어 있던 로그인/콜백 라우터를 /auth/login, /auth/callback 공용 경로로 통합
* [x] Cognito 토큰 검증 로직: AWS JWKS를 캐싱하여 ID 토큰의 서명과 유효성을 검증하는 verify_cognito_token 보안 함수 구현
* [x] 유저 프로세싱 및 이미지 처리: 로그인 시 페이로드에서 유저 정보를 추출하여 DB에 저장하고, 프로필 이미지를 리사이징하여 S3에 업로드하는 process_cognito_login 서비스 로직 구현
* [x] 의존성 추가: Cognito 토큰 기반으로 현재 접속 유저를 식별하는 get_current_user_by_cognito 의존성 추가. **기존의 의존성 교체필요 없음.** 

🧪 테스트
* [x] 로컬 테스트 완료 (uv run pytest -q)
* [x] ruff/mypy 통과 확인
    * [x] uv run ruff check .
    * [x] uv run ruff format --check .
    * [x] uv run mypy .
    
⚠️ 리뷰 포인트 / 주의사항
* 네이버 연동 실패: 네이버는 openid 스코프 요청 시 에러를 뱉으나 cognito에서 제외할 방안이 없습니다. 이로인해 제외되었습니다.
* 대소문자 민감도: Cognito 콘솔에 등록된 ID 제공업체 이름과 ProviderChoice의 문자열 값이 정확히 일치해야 리다이렉트 에러가 발생하지 않습니다. 

✅ 체크리스트
* [x] 커밋 메시지 컨벤션을 준수했습니다.
* [x] 불필요한 주석/로그를 제거했습니다.
* [x] 문서/설정 변경이 필요하면 반영했습니다.
* [x] 애플 연동을 고려하였으나 현실적 벽에 막혔습니다. IOS 개발 할거아니면 불가능.