### PR TITLE
Near 128 split concert session crud

### DIFF
--- a/app/admin/resources.py
+++ b/app/admin/resources.py
@@ -232,14 +232,14 @@ class ConcertSessionAdmin(TortoiseModelAdmin):
         data = SessionCreateRequest(
             **parsed_payload,
             artist_ids=artist_ids,
-            channel_config=ChannelConfig(),
         )
 
         service = StreamAdminService(
             ivs_client=IVSClient(), playback_provider=IVSPlaybackProvider()
         )
-        session_res = await service.create_session_with_infrastructure(
-            concert_id, data, user=cast("User", None)
+        session_res = await service.create_session(concert_id, data, user=cast("User", None))
+        await service.provision_channel(
+            session_res.id, user=cast("User", None), config=ChannelConfig()
         )
 
         obj = await self.orm_get_obj(session_res.id)

--- a/app/domains/chat/service.py
+++ b/app/domains/chat/service.py
@@ -62,6 +62,8 @@ class ChatService:
     async def handle_connection(self, ws: WebSocket, room_id: str, user_id: str) -> None:
         room_id = room_id.strip()
         user_id = user_id.strip()
+        if not await ConcertSession.exists(id=int(room_id)):
+            return
 
         try:
             await self.manager.connect(room_id, ws)

--- a/app/domains/chat/service.py
+++ b/app/domains/chat/service.py
@@ -10,7 +10,7 @@ from pydantic_core import ValidationError
 from app.domains.chat.manager import ConnectionLimitError, ConnectionManager
 from app.domains.chat.repository import append_chat_message, get_recent_messages, rate_limit_ok
 from app.domains.chat.schemas import ClientMessage, ServerEvent
-from app.domains.streams.models import ConcertSession
+from app.domains.streams.models import ConcertSession, StreamChannel
 
 
 def now_iso() -> str:
@@ -45,8 +45,9 @@ class ChatService:
         except ValueError as err:
             raise InvalidRoomId("Invalid stream_id") from err
 
-        exists = await ConcertSession.exists(id=stream_id)
-        if not exists:
+        if not await ConcertSession.exists(id=stream_id):
+            raise StreamNotFound("stream not found")
+        if not await StreamChannel.exists(session_id=stream_id):
             raise StreamNotFound("stream not found")
 
         return str(stream_id)
@@ -63,6 +64,8 @@ class ChatService:
         room_id = room_id.strip()
         user_id = user_id.strip()
         if not await ConcertSession.exists(id=int(room_id)):
+            return
+        if not await StreamChannel.exists(session_id=int(room_id)):
             return
 
         try:

--- a/app/domains/streams/admin/router.py
+++ b/app/domains/streams/admin/router.py
@@ -6,7 +6,6 @@ from fastapi import (
     Query,
     status,
 )
-from fastapi.templating import Jinja2Templates
 
 from app.api.deps import get_admin_user
 from app.domains.streams import deps as streams_deps
@@ -21,8 +20,6 @@ from app.domains.streams.admin.service import StreamAdminService
 from app.domains.users.models import User
 
 router = APIRouter(prefix="/admin/streams", tags=["스트리밍 관리"])
-templates = Jinja2Templates(directory="app/admin/templates")
-
 
 @router.post(
     "/concerts/{concert_id}/sessions",

--- a/app/domains/streams/admin/router.py
+++ b/app/domains/streams/admin/router.py
@@ -11,6 +11,7 @@ from app.api.deps import get_admin_user
 from app.domains.streams import deps as streams_deps
 from app.domains.streams.admin.schemas import (
     ChannelConfig,
+    IVSUpdateConfig,
     SessionCreateRequest,
     SessionListResponse,
     SessionResponse,
@@ -32,7 +33,7 @@ router = APIRouter(prefix="/admin/streams", tags=["스트리밍 관리"])
 )
 async def create_concert_stream(
     concert_id: int = Path(..., description="콘서트 ID"),
-    data: SessionCreateRequest = Body(..., description="새로운 콘서트 세션과 IVS config 상세 정보"),
+    data: SessionCreateRequest = Body(..., description="새로운 콘서트 세션 정보"),
     current_admin: User = Depends(get_admin_user),
     service: StreamAdminService = Depends(streams_deps.get_stream_admin_service),
 ) -> SessionResponse:
@@ -90,9 +91,7 @@ async def get_concert_session_detail(
 @router.patch(
     "/sessions/{session_id}",
     response_model=SessionResponse,
-    summary="콘서트 세션 및 인프라 수정",
-    description="세션 정보와 IVS 설정을 부분 수정합니다. \
-        channel_config 전달 시 AWS 설정도 즉시 변경됩니다.",
+    summary="콘서트 세션 수정",
 )
 async def update_concert_session(
     session_id: int = Path(..., description="수정할 세션 ID"),
@@ -100,7 +99,21 @@ async def update_concert_session(
     current_admin: User = Depends(get_admin_user),
     service: StreamAdminService = Depends(streams_deps.get_stream_admin_service),
 ) -> SessionResponse:
-    return await service.update_session_infrastructure(session_id, data, current_admin)
+    return await service.update_session(session_id, data, current_admin)
+
+
+@router.patch(
+    "/sessions/{session_id}/config",
+    response_model=SessionResponse,
+    summary="콘서트 채널 설정 수정",
+)
+async def update_concert_channel_config(
+    config: IVSUpdateConfig,
+    session_id: int = Path(..., description="수정할 세션 ID"),
+    current_admin: User = Depends(get_admin_user),
+    service: StreamAdminService = Depends(streams_deps.get_stream_admin_service),
+) -> SessionResponse:
+    return await service.update_channel_config(session_id, config, current_admin)
 
 
 @router.delete(

--- a/app/domains/streams/admin/router.py
+++ b/app/domains/streams/admin/router.py
@@ -10,6 +10,7 @@ from fastapi import (
 from app.api.deps import get_admin_user
 from app.domains.streams import deps as streams_deps
 from app.domains.streams.admin.schemas import (
+    ChannelConfig,
     SessionCreateRequest,
     SessionListResponse,
     SessionResponse,
@@ -21,12 +22,13 @@ from app.domains.users.models import User
 
 router = APIRouter(prefix="/admin/streams", tags=["스트리밍 관리"])
 
+
 @router.post(
     "/concerts/{concert_id}/sessions",
     status_code=status.HTTP_201_CREATED,
-    summary="콘서트 세션 생성 - IVS 채널 자동 설정",
+    summary="콘서트 세션 생성",
     response_model=SessionResponse,
-    description="특정 콘서트의 회차를 생성하고, AWS IVS 채널 리소스를 자동으로 할당합니다.",
+    description="특정 콘서트의 회차를 생성합니다.",
 )
 async def create_concert_stream(
     concert_id: int = Path(..., description="콘서트 ID"),
@@ -34,12 +36,26 @@ async def create_concert_stream(
     current_admin: User = Depends(get_admin_user),
     service: StreamAdminService = Depends(streams_deps.get_stream_admin_service),
 ) -> SessionResponse:
+    return await service.create_session(concert_id, data, current_admin)
+
+
+@router.post(
+    "/concerts/{concert_id}/sessions/provision",
+    status_code=status.HTTP_201_CREATED,
+    response_model=SessionResponse,
+    summary="기존 세션에 AWS IVS 채널 발급",
+)
+async def provision_concert_stream(
+    session_id: int,
+    config: ChannelConfig,
+    current_admin: User = Depends(get_admin_user),
+    service: StreamAdminService = Depends(streams_deps.get_stream_admin_service),
+) -> SessionResponse:
     """
-    1. 콘서트 회차(Session) 레코드를 생성합니다.
-    2. AWS IVS `CreateChannel` API를 호출하여 송출/재생 엔드포인트를 확보합니다.
-    3. 발급된 스트림 키는 내부 보안 정책에 따라 암호화하여 저장합니다.
+    1. AWS IVS `CreateChannel` API를 호출하여 송출/재생 엔드포인트를 확보합니다.
+    2. 발급된 스트림 키는 내부 보안 정책에 따라 암호화하여 저장합니다.
     """
-    return await service.create_session_with_infrastructure(concert_id, data, current_admin)
+    return await service.provision_channel(session_id, current_admin, config)
 
 
 @router.get(

--- a/app/domains/streams/admin/router.py
+++ b/app/domains/streams/admin/router.py
@@ -109,7 +109,7 @@ async def update_concert_session(
 )
 async def update_concert_channel_config(
     config: IVSUpdateConfig,
-    session_id: int = Path(..., description="수정할 세션 ID"),
+    session_id: int = Path(..., description="수정할 채널의 세션 ID"),
     current_admin: User = Depends(get_admin_user),
     service: StreamAdminService = Depends(streams_deps.get_stream_admin_service),
 ) -> SessionResponse:
@@ -117,10 +117,24 @@ async def update_concert_channel_config(
 
 
 @router.delete(
+    "/sessions/{session_id}/channel",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="IVS 채널 삭제",
+    description="특정 AWS IVS 채널 리소스를 즉시 삭제",
+)
+async def delete_channel(
+    session_id: int = Path(..., description="삭제할 채널의 세션 ID"),
+    current_admin: User = Depends(get_admin_user),
+    service: StreamAdminService = Depends(streams_deps.get_stream_admin_service),
+) -> None:
+    return await service.delete_stream_channel(session_id, current_admin)
+
+
+@router.delete(
     "/sessions/{session_id}",
     status_code=status.HTTP_204_NO_CONTENT,
-    summary="콘서트 세션 및 인프라 삭제",
-    description="특정 세션을 삭제하고, 연결된 AWS IVS 채널 리소스를 즉시 삭제",
+    summary="콘서트 세션 삭제",
+    description="특정 세션을 삭제하고, 연결된 AWS IVS 채널 리소스가 있을 시 함께 삭제",
 )
 async def delete_concert_session(
     session_id: int = Path(..., description="삭제할 세션 ID"),

--- a/app/domains/streams/admin/router.py
+++ b/app/domains/streams/admin/router.py
@@ -40,7 +40,7 @@ async def create_concert_stream(
 
 
 @router.post(
-    "/concerts/{concert_id}/sessions/provision",
+    "/sessions/{session_id}",
     status_code=status.HTTP_201_CREATED,
     response_model=SessionResponse,
     summary="기존 세션에 AWS IVS 채널 발급",

--- a/app/domains/streams/admin/schemas.py
+++ b/app/domains/streams/admin/schemas.py
@@ -73,9 +73,6 @@ class SessionCreateRequest(BaseModel):
     # 검색/필터링을 위한 아티스트 연결
     artist_ids: list[int] = Field(default_factory=list, description="출연 아티스트 ID 목록")
 
-    # 채널 설정 (기본값 제공)
-    channel_config: ChannelConfig = Field(default_factory=ChannelConfig)
-
 
 class SessionUpdateRequest(BaseModel):
     """세션 수정 요청 스키마"""

--- a/app/domains/streams/admin/schemas.py
+++ b/app/domains/streams/admin/schemas.py
@@ -84,7 +84,6 @@ class SessionUpdateRequest(BaseModel):
     access_level: AccessLevel | None = None
     is_test: bool | None = None
     artist_ids: list[int] | None = None  # 라인업
-    channel_config: IVSUpdateConfig | None = None  # IVS  채널 수정
 
 
 # ==================== 응답 스키마 ====================

--- a/app/domains/streams/admin/service.py
+++ b/app/domains/streams/admin/service.py
@@ -217,11 +217,11 @@ class StreamAdminService:
         )
 
     # ==============================================================================================
-    async def create_session_with_infrastructure(
+    async def create_session(
         self, concert_id: int, data: SessionCreateRequest, user: User | None = None
     ) -> SessionResponse:
         """
-        [Admin] 콘서트 세션 생성 및 AWS IVS 채널 자동 발급
+        [Admin] 콘서트 세션 생성 (channel은 none)
         """
         # 콘서트, 아티스트 검증
         concert = await self._get_concert_or_raise(concert_id)
@@ -235,9 +235,23 @@ class StreamAdminService:
             for artist in artists:
                 await ConcertArtist.create(session=session, artist=artist)
 
+        return self._map_to_session_response(session, channel=None)
+
+    async def provision_channel(
+        self, session_id: int, user: User | None, config: ChannelConfig
+    ) -> SessionResponse:
+        """
+        [Admin] 기존 세션에 AWS IVS 채널 발급
+        """
+        session = await self._get_session_with_channel_or_raise(session_id)
+
+        if session.stream_channel:
+            raise HTTPException(400, "Channel already exists for this session")
+
         created_arn = None
+
         try:
-            ivs_res = self._create_ivs_channel_infra(session, data.channel_config)
+            ivs_res = self._create_ivs_channel_infra(session, config)
             created_arn = ivs_res["channel"]["arn"]
             raw_key = ivs_res["streamKey"]["value"]
 
@@ -246,8 +260,8 @@ class StreamAdminService:
                 channel_arn=created_arn,
                 ingest_endpoint=ivs_res["channel"]["ingestEndpoint"],
                 playback_url=ivs_res["channel"]["playbackUrl"],
-                latency_mode=data.channel_config.latency_mode,
-                type=data.channel_config.channel_type,
+                latency_mode=config.latency_mode,
+                type=config.channel_type,
                 is_private=(session.access_level != AccessLevel.PUBLIC),
             )
             channel.set_stream_key(raw_key)
@@ -257,14 +271,10 @@ class StreamAdminService:
 
             return self._map_to_session_response(session, channel, raw_key)
 
-        except HTTPException:
-            await self._cleanup_on_failure(session.id, created_arn)
-            raise
-
-        except Exception as e:  # 그 외 에러
-            await self._cleanup_on_failure(session.id, created_arn)
-            logger.exception("Unexpected error during session creation")
-            raise HTTPException(500, "IVS Channel creation failed") from e
+        except Exception as e:
+            await self._cleanup_on_failure(session_id=None, channel_arn=created_arn)
+            logger.exception("IVS Channel provisioning failed")
+            raise HTTPException(500, "Failed to provision IVS Channel") from e
 
     async def update_session_infrastructure(
         self, session_id: int, data: SessionUpdateRequest, user: User

--- a/app/domains/streams/admin/service.py
+++ b/app/domains/streams/admin/service.py
@@ -276,8 +276,8 @@ class StreamAdminService:
             logger.exception("IVS Channel provisioning failed")
             raise HTTPException(500, "Failed to provision IVS Channel") from e
 
-    async def update_session_infrastructure(
-        self, session_id: int, data: SessionUpdateRequest, user: User
+    async def update_session(
+        self, session_id: int, data: SessionUpdateRequest, user: User | None
     ) -> SessionResponse:
         """
         [Admin] 콘서트 세션 수정
@@ -303,20 +303,30 @@ class StreamAdminService:
 
             await session.save()
 
-        # 인프라 설정 변경
-        if data.channel_config and channel:
-            self._update_ivs_channel_infra(session, channel, data.channel_config)
-
-            # DB 채널 상태 동기화
-            if data.channel_config.latency_mode:
-                channel.latency_mode = data.channel_config.latency_mode
-            if data.channel_config.channel_type:
-                channel.type = data.channel_config.channel_type
-            channel.is_private = session.access_level != AccessLevel.PUBLIC
-            await channel.save()
-
         if data.start_at and data.start_at != start_at_before:
             reschedule_session_notifications.delay(session.id)
+
+        return self._map_to_session_response(session, channel)
+
+    async def update_channel_config(
+        self, session_id: int, config: IVSUpdateConfig, user: User | None
+    ) -> SessionResponse:
+        """
+        [Admin] 콘서트 채널 수정
+        """
+        session = await self._get_session_with_channel_or_raise(session_id)
+        channel = session.stream_channel
+        # 인프라 설정 변경
+        if config and channel:
+            self._update_ivs_channel_infra(session, channel, config)
+
+            # DB 채널 상태 동기화
+            if config.latency_mode:
+                channel.latency_mode = config.latency_mode
+            if config.channel_type:
+                channel.type = config.channel_type
+            channel.is_private = session.access_level != AccessLevel.PUBLIC
+            await channel.save()
 
         return self._map_to_session_response(session, channel)
 

--- a/app/domains/streams/admin/service.py
+++ b/app/domains/streams/admin/service.py
@@ -352,10 +352,28 @@ class StreamAdminService:
         """
         session = await self._get_session_with_channel_or_raise(session_id)
         channel = session.stream_channel
-        if not channel:
-            raise HTTPException(404, f"Channel {channel.id} not found")
 
         return self._map_to_session_response(session, channel)
+
+    async def delete_stream_channel(self, session_id: int, user: User) -> None:
+        """
+        [Admin] IVS 채널 삭제
+        """
+        session = await self._get_session_with_channel_or_raise(session_id)
+        channel = getattr(session, "stream_channel", None)
+
+        if not channel:
+            return
+
+        if channel.channel_arn:
+            try:
+                self.ivs_client.delete_channel(channel.channel_arn)
+            except Exception as e:
+                logger.warning(f"AWS Delete Fail (ARN: {channel.channel_arn}): {e}")
+        await channel.delete()
+
+        session.status = StreamStatus.READY
+        await session.save()
 
     async def delete_session_with_infrastructure(self, session_id: int, user: User) -> None:
         """

--- a/tests/chat/test_chat.py
+++ b/tests/chat/test_chat.py
@@ -103,9 +103,15 @@ def override_ws_user():
 # ✅ stream 존재 검증을 통과시키기 (ConcertSession.exists 패치)
 @pytest.fixture()
 def patch_stream_exists_true():
-    with patch(
-        "app.domains.chat.service.ConcertSession.exists",
-        new=AsyncMock(return_value=True),
+    with (
+        patch(
+            "app.domains.chat.service.ConcertSession.exists",
+            new=AsyncMock(return_value=True),
+        ),
+        patch(
+            "app.domains.chat.service.StreamChannel.exists",
+            new=AsyncMock(return_value=True),
+        ),
     ):
         yield
 

--- a/tests/streams/admin/test_get_and_update_session.py
+++ b/tests/streams/admin/test_get_and_update_session.py
@@ -4,7 +4,7 @@ import pytest
 from fastapi import HTTPException
 
 from app.domains.concerts.models import CategoryType, Concert
-from app.domains.streams.admin.schemas import SessionUpdateRequest
+from app.domains.streams.admin.schemas import IVSUpdateConfig, SessionUpdateRequest
 from app.domains.streams.admin.service import StreamAdminService
 from app.domains.streams.models import (
     AccessLevel,
@@ -152,18 +152,25 @@ async def test_update_session_updates_db_and_calls_aws(
     data = SessionUpdateRequest(
         session_name="수정됨",
         access_level=AccessLevel.ADMIN_ONLY,
-        channel_config={"latencyMode": LatencyMode.NORMAL},
     )
 
-    res = await service.update_session_infrastructure(
+    res = await service.update_session(
         session_with_channel.id,
         data,
         admin_user,
     )
 
+    aws_data = IVSUpdateConfig(
+        latency_mode=LatencyMode.LOW,
+        type=ChannelType.STANDARD,
+    )
+
+    aws_res = await service.update_channel_config(session_with_channel.id, aws_data, admin_user)
+
     assert called.get("yes") is True
     assert res.session_name == "수정됨"
     assert res.access_level == AccessLevel.ADMIN_ONLY
+    assert aws_res.channel.latency_mode == LatencyMode.LOW
 
 
 @pytest.mark.asyncio

--- a/tests/streams/admin/test_router.py
+++ b/tests/streams/admin/test_router.py
@@ -51,9 +51,13 @@ class TestStreamRouter:
                     new_callable=AsyncMock,
                 ) as mock_create_concert,
                 patch(
-                    "app.domains.streams.admin.service.StreamAdminService.create_session_with_infrastructure",
+                    "app.domains.streams.admin.service.StreamAdminService.create_session",
                     new_callable=AsyncMock,
                 ) as mock_create_session,
+                patch(
+                    "app.domains.streams.admin.service.StreamAdminService.provision_channel",
+                    new_callable=AsyncMock,
+                ) as mock_provision_channel,
             ):
                 # concert mock
                 mock_concert = MagicMock(spec=Concert)
@@ -90,6 +94,26 @@ class TestStreamRouter:
                     access_level=AccessLevel.PUBLIC,
                     start_at=datetime.now(),
                     status=StreamStatus.READY,
+                )
+
+                # create session
+                res = await client.post(
+                    "/api/v1/admin/streams/concerts/1/sessions",
+                    json={
+                        "session_name": "Session 1",
+                        "access_level": "PUBLIC",
+                        "start_at": datetime.now().isoformat(),
+                        "artist_ids": [1, 2],
+                    },
+                )
+                assert res.status_code == 201
+
+                mock_provision_channel.return_value = SessionResponse(
+                    id=10,
+                    session_name="Session 1",
+                    access_level=AccessLevel.PUBLIC,
+                    start_at=datetime.now(),
+                    status=StreamStatus.READY,
                     channel=IVSChannelSummary(
                         arn="arn:test",
                         ingest_endpoint="rtmps://test",
@@ -100,23 +124,18 @@ class TestStreamRouter:
                     value="sk_test",
                 )
 
-                # create session
-                res = await client.post(
-                    "/api/v1/admin/streams/concerts/1/sessions",
+                # create channel
+                chan_res = await client.post(
+                    "/api/v1/admin/streams/sessions/10",
                     json={
-                        "session_name": "Session 1",
-                        "access_level": "PUBLIC",
-                        "start_at": datetime.now().isoformat(),
                         "channel_config": {
                             "latency_mode": "LOW",
                             "channel_type": "STANDARD",
                         },
-                        "artist_ids": [1, 2],
                     },
                 )
-
                 assert res.status_code == 201
-                assert res.json()["value"] == "sk_test"
+                assert chan_res.json()["value"] == "sk_test"
 
         finally:
             app.dependency_overrides.clear()

--- a/tests/streams/admin/test_service.py
+++ b/tests/streams/admin/test_service.py
@@ -89,21 +89,36 @@ def bypass_stream_key_crypto(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_create_session_with_infrastructure(admin_service, admin_user, concert):
+async def test_create_session(admin_service, admin_user, concert):
     req = SessionCreateRequest(
         session_name="라이브 세션",
         start_at=now_kst() + timedelta(hours=1),
         access_level=AccessLevel.PUBLIC,
-        channel_config=ChannelConfig(
-            latency_mode=LatencyMode.LOW,
-            type=ChannelType.STANDARD,
-        ),
     )
 
-    res = await admin_service.create_session_with_infrastructure(concert.id, req, admin_user)
+    res = await admin_service.create_session(concert.id, req, admin_user)
 
     assert res.session_name == "라이브 세션"
     assert res.status == StreamStatus.READY
+
+
+@pytest.mark.asyncio
+async def test_create_channel(admin_service, admin_user, concert):
+    session = await ConcertSession.create(
+        concert=concert,
+        session_name="채널 생성용 세션",
+        start_at=now_kst() + timedelta(hours=1),
+        access_level=AccessLevel.PUBLIC,
+        status=StreamStatus.READY,
+    )
+
+    config = ChannelConfig(
+        latency_mode=LatencyMode.LOW,
+        type=ChannelType.STANDARD,
+    )
+
+    res = await admin_service.provision_channel(session.id, admin_user, config)
+
     assert res.channel is not None
     assert res.channel.arn == "arn:ivs:test:channel/1"
     assert res.stream_key == "raw-stream-key"


### PR DESCRIPTION
## ✅ PR 한줄 요약
- 콘서트 세션 CRUD와 IVS 채널 발급/수정/삭제를 분리한 후 어드민 흐름을 재연결하고, 채팅은 세션+채널 존재 조건을 추가.

## 🔗 관련 이슈
- Jira: NEAR-128

## 🛠️ 변경 내용
- [x]  콘서트 세션 생성/수정과 IVS 인프라 생성/수정 로직 분리 및 엔드포인트 흐름 정리
- [x] IVS 채널 발급/삭제 경로 수정 및 어드민 연동 로직 보완
- [x] 채팅 접속 조건(세션+채널 존재) 강화와 관련 테스트 코드 수정 반영

## 🧪 테스트
- [x] 로컬 테스트 완료 (`uv run pytest -q`)
- [x] ruff/mypy 통과 확인
  - [x] `uv run ruff check .`
  - [x] `uv run ruff format --check .`
  - [x] `uv run mypy .`

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했습니다.
- [x] 불필요한 주석/로그를 제거했습니다.
- [x] 문서/설정 변경이 필요하면 반영했습니다.