### PR TITLE
Near 133 artist recommendation

### DIFF
--- a/app/api/router.py
+++ b/app/api/router.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter
 
+from app.domains.artists.router import recs_router
 from app.domains.artists.router import router as artists_router
 from app.domains.auth.router import router as auth_router
 from app.domains.chat.router_ws import router as chat_router
@@ -16,6 +17,7 @@ api_router = APIRouter(prefix="/api/v1")
 api_router.include_router(auth_router)
 api_router.include_router(users_router)
 api_router.include_router(artists_router)
+api_router.include_router(recs_router)
 api_router.include_router(concert_admin_router)
 api_router.include_router(streams_router)
 api_router.include_router(streams_status_router)

--- a/app/domains/artists/router.py
+++ b/app/domains/artists/router.py
@@ -1,11 +1,18 @@
 from enum import Enum
 
-from fastapi import APIRouter, Query, status
+from fastapi import APIRouter, Depends, Query, status
 
-from app.domains.artists.schemas import ArtistDetailResponse, ArtistListResponse
+from app.api.deps import get_current_user
+from app.domains.artists.schemas import (
+    ArtistDetailResponse,
+    ArtistListResponse,
+    ArtistRecommendationResponse,
+)
 from app.domains.artists.service import artist_service
+from app.domains.users.models import User
 
 router = APIRouter(prefix="/artists", tags=["artists"])
+recs_router = APIRouter(prefix="/recommendations", tags=["추천"])
 
 
 class ArtistSortOrder(str, Enum):
@@ -53,3 +60,22 @@ async def get_artist_detail(
     특정 아티스트의 상세 정보를 조회합니다.
     """
     return await artist_service.get_artist_detail(artist_id=artist_id)
+
+
+@recs_router.get(
+    "/artists", response_model=ArtistRecommendationResponse, summary="사용자 맞춤 아티스트 추천"
+)
+async def get_artist_recommendations(
+    current_user: User = Depends(get_current_user), limit: int = Query(10, ge=1, le=50)
+) -> ArtistRecommendationResponse:
+    """
+    로그인한 유저의 팔로우 목록을 기반으로 아티스트를 추천합니다.
+    캐시(Redis)가 존재하면 즉시 반환하고, 없으면 계산합니다.
+    """
+    # 서비스로부터 ArtistListElement 리스트를 받아옵니다.
+    items = await artist_service.get_personalized_recommendations(
+        user_id=current_user.id, limit=limit
+    )
+
+    # Response 객체로 감싸서 반환
+    return ArtistRecommendationResponse(recommended_artists=items)

--- a/app/domains/artists/schemas.py
+++ b/app/domains/artists/schemas.py
@@ -35,3 +35,13 @@ class ArtistDetailResponse(ArtistListElement):
     debut_date: date | None
     member_count: int | None
     group_type: GroupType | None
+
+
+class ArtistRecommendationElement(ArtistBase):
+    company: str | None = Field(None, alias="agency")
+    follower_count: int
+    recommendation_reason: str
+
+
+class ArtistRecommendationResponse(BaseModel):
+    recommended_artists: list[ArtistRecommendationElement]

--- a/app/domains/artists/service.py
+++ b/app/domains/artists/service.py
@@ -1,5 +1,6 @@
 import json
-from typing import Any, cast
+from collections.abc import Iterable
+from typing import TYPE_CHECKING, Any, cast
 
 from fastapi import HTTPException, status
 from tortoise.functions import Count
@@ -7,6 +8,10 @@ from tortoise.functions import Count
 from app.core.redis import redis_client
 from app.domains.artists.models import Artist, Follow
 from app.domains.artists.schemas import ArtistDetailResponse, ArtistListElement, ArtistListResponse
+
+# Ruff TC003: 타입 힌트용 임포트를 체크 블록으로 이동
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 
 class ArtistService:
@@ -93,7 +98,7 @@ class ArtistService:
     async def _get_fallback_artists(
         self, limit: int, exclude_ids: list[int] | None = None
     ) -> list[Any]:
-        """최신 등록 순으로 아티스트를 가져오는 공통 로직 """
+        """최신 등록 순으로 아티스트를 가져오는 공통 로직"""
         query = Artist.all().annotate(follower_count=Count("followers"))
         if exclude_ids:
             query = query.filter(id__not_in=exclude_ids)
@@ -168,7 +173,10 @@ class ArtistService:
         if len(result) < limit:
             needed = limit - len(result)
             # 이미 포함된 아티스트와 내 팔로우 목록 제외
-            exclude = list(my_follows) + [item["id"] for item in result]
+            follow_ids = [int(f) for f in cast("Iterable[Any]", my_follows or [])]
+            result_ids = [int(item["id"]) for item in result]
+
+            exclude: list[int] = follow_ids + result_ids
             fallbacks = await self._get_fallback_artists(limit=needed, exclude_ids=exclude)
 
             result.extend(

--- a/app/domains/artists/service.py
+++ b/app/domains/artists/service.py
@@ -1,7 +1,11 @@
+import json
+from typing import Any, cast
+
 from fastapi import HTTPException, status
 from tortoise.functions import Count
 
-from app.domains.artists.models import Artist
+from app.core.redis import redis_client
+from app.domains.artists.models import Artist, Follow
 from app.domains.artists.schemas import ArtistDetailResponse, ArtistListElement, ArtistListResponse
 
 
@@ -85,6 +89,111 @@ class ArtistService:
             group_type=artist.group_type,  #
             follower_count=getattr(artist, "follower_count", 0),  #
         )
+
+    async def _get_fallback_artists(
+        self, limit: int, exclude_ids: list[int] | None = None
+    ) -> list[Any]:
+        """최신 등록 순으로 아티스트를 가져오는 공통 로직 """
+        query = Artist.all().annotate(follower_count=Count("followers"))
+        if exclude_ids:
+            query = query.filter(id__not_in=exclude_ids)
+        return await query.order_by("-created_at").limit(limit)
+
+    async def get_personalized_recommendations(
+        self, user_id: int, limit: int = 10
+    ) -> list[dict[str, Any]]:
+        """
+        사용자 기반 협업 필터링 (Redis 캐싱 적용)
+        """
+        limit = min(limit, 50)  # 상한 50
+        cache_key = f"user_recommendation:{user_id}"
+
+        # Redis에서 캐시된 결과 확인
+        cached_data = await redis_client.get(cache_key)
+        if cached_data:
+            return cast("list[dict[str, Any]]", json.loads(cached_data))
+
+        # 캐시가 없으면 나와 팔로우가 겹치는 유저 기반으로 아티스트 추천 시작
+        # 내 팔로우 목록 가져오기
+        my_follows = await Follow.filter(user_id=user_id).values_list("artist_id", flat=True)
+        recommended_artists = []
+        reason = "회원님이 좋아하실만한 아티스트"  # 팔로우는 있지만 유사 사용자가 없을경우 출력
+
+        if not my_follows:
+            # 팔로우가 전혀 없는 경우: 최신 아티스트추천 + 팔로워 집계 (Cold Start 방어)
+            recommended_artists = await self._get_fallback_artists(limit)
+            reason = "최근 데뷔한 핫한 아티스트"
+        else:
+            # 나와 공통 팔로우가 많은 유저들이 팔로우한 다른 아티스트 추출
+            artist_ids_str = ",".join(map(str, my_follows))  # 내 팔로우
+            recommend_query = f"""
+                SELECT f.artist_id as id
+                FROM follows f
+                WHERE f.user_id IN (
+                    SELECT DISTINCT user_id 
+                    FROM follows 
+                    WHERE artist_id IN ({artist_ids_str}) AND user_id != {user_id}
+                )
+                AND f.artist_id NOT IN ({artist_ids_str})
+                GROUP BY f.artist_id
+                ORDER BY COUNT(f.user_id) DESC
+                LIMIT {limit}
+            """
+            raw_res: list[Any] = await Artist.raw(recommend_query)
+            artist_ids = [r.id for r in raw_res]
+
+            if not artist_ids:
+                # 유사 사용자가 없는 경우 기본 최신순
+                recommended_artists = await self._get_fallback_artists(limit)
+                reason = "최근 데뷔한 핫한 아티스트"
+            else:
+                # 추천된 ID들에 대해 팔로워 수 집계
+                recommended_artists = await Artist.filter(id__in=artist_ids).annotate(
+                    follower_count=Count("followers")
+                )
+                reason = "팔로우하신 아티스트와 유사한 스타일"
+
+        result = [
+            {
+                "id": recs.id,
+                "name": recs.stage_name,
+                "profile_image": recs.profile_img_url or "",
+                "company": recs.agency or "",
+                "follower_count": getattr(recs, "follower_count", 0),
+                "recommendation_reason": reason,
+            }
+            for recs in recommended_artists
+        ]
+
+        if len(result) < limit:
+            needed = limit - len(result)
+            # 이미 포함된 아티스트와 내 팔로우 목록 제외
+            exclude = list(my_follows) + [item["id"] for item in result]
+            fallbacks = await self._get_fallback_artists(limit=needed, exclude_ids=exclude)
+
+            result.extend(
+                [
+                    {
+                        "id": a.id,
+                        "name": a.stage_name,
+                        "profile_image": a.profile_img_url or "",
+                        "company": a.agency or "",
+                        "follower_count": getattr(a, "follower_count", 0),
+                        "recommendation_reason": "최근 데뷔한 핫한 아티스트",
+                    }
+                    for a in fallbacks
+                ]
+            )
+
+        # 4. Redis에 저장 (1시간 유지)
+        if result:
+            await redis_client.setex(
+                cache_key,
+                3600,  # 1시간(초)
+                json.dumps(result, ensure_ascii=False),
+            )
+
+        return result
 
 
 artist_service = ArtistService()

--- a/app/domains/users/service.py
+++ b/app/domains/users/service.py
@@ -6,6 +6,7 @@ from fastapi import HTTPException, Response, UploadFile, status
 from tortoise.transactions import in_transaction
 
 from app.core.config import settings
+from app.core.redis import redis_client
 from app.core.utils.image_resizer import ImageResizer
 from app.domains.artists.models import Artist, Follow
 from app.domains.notifications.models import UserNoti
@@ -204,6 +205,9 @@ class UserService:
     async def add_follow_artist(
         self, user: User, data: FavoriteArtistCreate
     ) -> FavoriteArtistResponse:
+        """
+        사용자의 선호 아티스트를 추가합니다.
+        """
         # 아티스트 존재 여부 확인
         artist = await Artist.get_or_none(id=data.artist_id)
         if not artist:
@@ -216,6 +220,9 @@ class UserService:
         follow, created = await Follow.get_or_create(user=user, artist=artist)
         if not created:
             raise HTTPException(status_code=409, detail="이미 추가된 아티스트입니다.")
+
+        # 추천 아티스트 캐시 삭제
+        await redis_client.delete(f"user_recommendation:{user.id}")
 
         return FavoriteArtistResponse(
             user_id=user.id,
@@ -241,7 +248,9 @@ class UserService:
         # 팔로우 기록 삭제
         await follow.delete()
 
-        # 성공하면
+        # 추천 아티스트 캐시 삭제
+        await redis_client.delete(f"user_recommendation:{user.id}")
+
         return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 

--- a/tests/artists/test_recommendations.py
+++ b/tests/artists/test_recommendations.py
@@ -1,0 +1,94 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.domains.artists.service import artist_service
+
+
+# Tortoise QuerySet의 비동기 동작을 흉내 내는 가장 확실한 클래스
+class MockQuerySet:
+    def __init__(self, items):
+        self.items = items
+
+    def __await__(self):
+        # await 시점에 즉시 self.items(리스트)를 반환하는 제너레이터
+        yield
+        return self.items
+
+    def __getattr__(self, name):
+        # 어떤 메서드(filter, all, limit 등)를 호출해도 다시 자기 자신(MockQuerySet)을 반환
+        return lambda *args, **kwargs: self
+
+
+@pytest.mark.asyncio
+async def test_recommend_cold_start_for_new_user(mocker):
+    """신규 유저(Cold Start) 추천 로직 검증"""
+    mocker.patch(
+        "app.domains.artists.service.redis_client.get", new_callable=AsyncMock, return_value=None
+    )
+    mocker.patch("app.domains.artists.service.redis_client.setex", new_callable=AsyncMock)
+
+    # 1. Follow.filter().values_list() 모킹
+    # values_list는 호출 즉시 await 되므로 AsyncMock이 적합합니다.
+    mock_follow_qs = MagicMock()
+    mock_follow_qs.values_list = AsyncMock(return_value=[])
+    mocker.patch("app.domains.artists.models.Follow.filter", return_value=mock_follow_qs)
+
+    # 2. Artist.all()... 결과물 모킹
+    mock_artist = MagicMock()
+    mock_artist.id = 1
+    mock_artist.stage_name = "New Artist"
+    mock_artist.profile_img_url = "http://image.com"
+    mock_artist.agency = "New Agency"
+    mock_artist.follower_count = 0
+
+    # Artist.all()이 호출되면 MockQuerySet 객체를 반환합니다.
+    mocker.patch("app.domains.artists.models.Artist.all", return_value=MockQuerySet([mock_artist]))
+
+    # 실행
+    result = await artist_service.get_personalized_recommendations(user_id=1)
+
+    # 검증
+    assert len(result) > 0
+    assert result[0]["recommendation_reason"] == "최근 데뷔한 핫한 아티스트"
+
+
+@pytest.mark.asyncio
+async def test_recommend_based_on_similar_users_logic(mocker):
+    """유사 사용자 기반 추천 로직 검증"""
+    mocker.patch(
+        "app.domains.artists.service.redis_client.get", new_callable=AsyncMock, return_value=None
+    )
+    mocker.patch("app.domains.artists.service.redis_client.setex", new_callable=AsyncMock)
+
+    # 1. 내 팔로우 목록 [10] 반환
+    mock_follow_qs = MagicMock()
+    mock_follow_qs.values_list = AsyncMock(return_value=[10])
+    mocker.patch("app.domains.artists.models.Follow.filter", return_value=mock_follow_qs)
+
+    # 2. Artist.raw() 결과 (service.py 132라인: [r.id for r in raw_res])
+    mock_raw_res = MagicMock()
+    mock_raw_res.id = 20
+    mocker.patch(
+        "app.domains.artists.models.Artist.raw", new_callable=AsyncMock, return_value=[mock_raw_res]
+    )
+
+    # 3. 최종 아티스트 상세 정보 쿼리 모킹
+    mock_artist = MagicMock()
+    mock_artist.id = 20
+    mock_artist.stage_name = "Similar Artist"
+    mock_artist.profile_img_url = None
+    mock_artist.agency = "Similar Agency"
+    mock_artist.follower_count = 5
+
+    # Artist.filter()가 MockQuerySet을 반환하게 하여 await 시 리스트가 나오게 함
+    mocker.patch(
+        "app.domains.artists.models.Artist.filter", return_value=MockQuerySet([mock_artist])
+    )
+
+    # 실행
+    result = await artist_service.get_personalized_recommendations(user_id=1)
+
+    # 검증
+    assert result[0]["id"] == 20
+    assert "유사한 스타일" in result[0]["recommendation_reason"]


### PR DESCRIPTION
✅ PR 한줄 요약
* 사용자 팔로우 기반 협업 필터링 아티스트 추천 시스템 구현 및 결과 보충(Fallback) 로직 적용 
🔗 관련 이슈
* Jira: NEAR-133 

🛠️ 변경 내용
* [x] 아티스트 추천 API 엔드포인트 및 스키마 추가: /recommendations/artists 라우터 신설 및 ArtistRecommendationResponse 스키마 정의
* [x] 협업 필터링 추천 엔진 구현: 유저 간 공통 팔로우 기반 아티스트 추천 로직(SQL raw query) 및 Redis 캐싱(1시간) 적용
* [x] 추천 결과 자동 보충(Fallback) 로직: 추천 결과가 limit보다 적을 경우 최신 아티스트로 부족한 수량을 채움.
* [x] 데이터 정합성 보장: 유저가 선호 아티스트를 추가/삭제할 경우 기존 추천 캐시를 즉시 삭제하도록 유저 서비스 수정 

사용자 1 - 유사한 팔로우의 사용자의 데이터가 존재하는 경우
<img width="1393" height="516" alt="image" src="https://github.com/user-attachments/assets/8d4e327a-0a6e-4bc4-b054-86deff135a7a" />

사용자2 - 유사한 팔로우의 사용자가 존재하지 않는경우
<img width="1404" height="466" alt="스크린샷 2026-02-06 오전 10 17 35" src="https://github.com/user-attachments/assets/1452745f-53b2-4244-8618-91b83d5c57e8" />


🧪 테스트
* [x] 로컬 테스트 완료 (uv run pytest -q)
* [x] ruff/mypy 통과 확인
    * [x] uv run ruff check .
    * [x] uv run ruff format --check .
    * [x] uv run mypy . 
    
⚠️ 리뷰 포인트 / 주의사항
* SQL Raw Query: Artist.raw()를 사용하여 유사 사용자를 추출합니다. 인덱스 활용 및 성능상 이슈가 없는지 쿼리 구조 확인 부탁드립니다.
* 보충 로직: 결과가 부족할 때 최신 아티스트를 가져오며, 이때 이미 추천된 아티스트나 본인이 팔로우한 아티스트는 id__not_in으로 중복 배제 처리했습니다.

✅ 체크리스트
* [x] 커밋 메시지 컨벤션을 준수했습니다.
* [x] 불필요한 주석/로그를 제거했습니다.
* [x] 문서/설정 변경이 필요하면 반영했습니다.