### PR TITLE
[NEAR-136] Refactor: 소셜 로그인 콜백 응답 방식을 JSON으로 변경

### DIFF
--- a/app/domains/auth/router.py
+++ b/app/domains/auth/router.py
@@ -2,7 +2,7 @@ import secrets
 from typing import Any
 
 from fastapi import APIRouter, Cookie, Depends, HTTPException, Query, Response, status
-from fastapi.responses import RedirectResponse
+from fastapi.responses import JSONResponse, RedirectResponse
 
 from app.api.deps import get_current_user_from_refresh_cookie, logger  # 유저 인증 의존성
 from app.core.config import settings
@@ -95,23 +95,23 @@ async def social_login(
 
 
 @router.get("/cognito/callback", include_in_schema=False, summary="소셜 로그인 공용 콜백")
-async def social_callback(response: Response, code: str = Query(...)) -> RedirectResponse:
+async def social_callback(response: Response, code: str = Query(...)) -> JSONResponse:
     """
     Cognito로부터 인가 코드를 받아 process_cognito_login을 실행합니다.
-    사용자가 직접 호출할 필요가 없으므로 API 문서에서 제외합니다.
+    Access Token은 바디에, Refresh Token은 쿠키에 담아 반환합니다.
     """
     token_data = await auth_service.process_cognito_login(code)
 
     # 화면으로 보낼 redirect url 구성 및 응답할 RedirectResponse 설정
-    redirect_url = (
-        f"{settings.CALLBACK_REDIRECT_URL}"
-        f"?access_token={token_data.access_token}"
-        f"&is_new_user={str(token_data.is_new_user).lower()}"
-    )
-    redirect_response = RedirectResponse(url=redirect_url)
+    content = {
+        "access_token": token_data.access_token,
+        "is_new_user": token_data.is_new_user,
+        "token_type": "Bearer",
+    }
+    response = JSONResponse(content=content, status_code=status.HTTP_200_OK)
 
     # Refresh Token을 HttpOnly 쿠키에 설정
-    redirect_response.set_cookie(
+    response.set_cookie(
         key="refresh_token",
         value=token_data.refresh_token,
         httponly=True,
@@ -121,7 +121,7 @@ async def social_callback(response: Response, code: str = Query(...)) -> Redirec
         max_age=settings.REFRESH_TOKEN_EXPIRE_DAYS * 24 * 3600,  # 7 * 24 * 60* 60
     )
 
-    return redirect_response
+    return response
 
 
 @router.get("/naver/callback", include_in_schema=False, summary="네이버 로그인 공용 콜백")

--- a/tests/auth/test_router.py
+++ b/tests/auth/test_router.py
@@ -17,7 +17,7 @@ async def ac():
 
 @pytest.mark.asyncio
 async def test_kakao_callback_endpoint(mocker):
-    """카카오 콜백 시 프론트엔드로 리다이렉트되는지 확인"""
+    """카카오 콜백 시 JSON 응답과 쿠키가 정상적으로 반환되는지 확인"""
     # 1. 서비스 로직 모킹
     mock_service = mocker.patch(
         "app.domains.auth.router.auth_service.process_cognito_login", new_callable=AsyncMock
@@ -30,18 +30,17 @@ async def test_kakao_callback_endpoint(mocker):
     )
 
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
-        # follow_redirects=False로 설정해야 302 응답 자체를 검증할 수 있습니다.
-        response = await ac.get(
-            "/api/v1/auth/cognito/callback?code=mock_code", follow_redirects=False
-        )
+        # 이제 리다이렉트가 아니므로 follow_redirects 옵션은 의미가 없지만 유지해도 무방합니다.
+        response = await ac.get("/api/v1/auth/cognito/callback?code=mock_code")
 
-    # 2. 검증: 302/307 리다이렉트 확인.
-    assert response.status_code in [302, 307]
+    # 2. 검증: 200 OK 확인
+    assert response.status_code == 200
 
-    # 3. 검증: Location 헤더에 토큰과 정보가 포함되어 있는지 확인
-    location = response.headers["location"]
-    assert "access_token=test_token" in location
-    assert "is_new_user=false" in location
+    # 3. 검증: 응답 바디(JSON)에 토큰 정보가 포함되어 있는지 확인
+    data = response.json()
+    assert data["access_token"] == "test_token"
+    assert data["is_new_user"] is False
+    assert data["token_type"] == "Bearer"
 
     # 4. 검증: 쿠키가 정상적으로 설정되었는지 확인
     set_cookies = response.headers.get_list("set-cookie")
@@ -51,22 +50,24 @@ async def test_kakao_callback_endpoint(mocker):
 
 @pytest.mark.asyncio
 async def test_kakao_callback_logic(mocker):
-    """router.py 56-64 라인 커버: 리다이렉트 및 쿠키 설정"""
-    from app.domains.auth.schemas import TokenResponse
-
+    """JSON 응답 및 바디 데이터 구조 검증"""
     mock_token = TokenResponse(
         access_token="at", refresh_token="rt", token_type="bearer", is_new_user=True
     )
     mocker.patch(
-        "app.domains.auth.router.auth_service.process_cognito_login", return_value=mock_token
+        "app.domains.auth.router.auth_service.process_cognito_login",
+        new_callable=AsyncMock,
+        return_value=mock_token,
     )
 
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
-        response = await ac.get("/api/v1/auth/cognito/callback?code=mock", follow_redirects=False)
+        response = await ac.get("/api/v1/auth/cognito/callback?code=mock")
 
-    assert response.status_code == 307
+    assert response.status_code == 200
+    data = response.json()
+    assert data["access_token"] == "at"
+    assert data["is_new_user"] is True
     assert "refresh_token=rt" in response.headers.get("set-cookie")
-    assert "is_new_user=true" in response.headers.get("location")
 
 
 @pytest.mark.asyncio
@@ -105,15 +106,11 @@ async def test_admin_login_endpoint_coverage(initialize_tests):
 
 @pytest.mark.asyncio
 async def test_kakao_callback_cookie_logic_coverage(mocker):
-    """router.py: 콜백 시 리다이렉트 및 쿠키 설정 상세 커버"""
-    from app.domains.auth.schemas import TokenResponse
-
-    # 1. 반환값 설정
+    """쿠키의 상세 옵션(Secure, SameSite, HttpOnly) 검증"""
     mock_token = TokenResponse(
         access_token="at", refresh_token="rt", token_type="bearer", is_new_user=True
     )
 
-    # 서비스 메서드 모킹
     mocker.patch(
         "app.domains.auth.router.auth_service.process_cognito_login",
         new_callable=AsyncMock,
@@ -121,25 +118,22 @@ async def test_kakao_callback_cookie_logic_coverage(mocker):
     )
 
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
-        response = await ac.get(
-            "/api/v1/auth/cognito/callback?code=fake_code", follow_redirects=False
-        )
+        response = await ac.get("/api/v1/auth/cognito/callback?code=fake_code")
 
-    # 2. 검증: 상태 코드 확인
-    assert response.status_code in [302, 307]
+    # 1. 상태 코드 확인
+    assert response.status_code == 200
 
-    # 3. 쿠키 설정 확인
-    set_cookie = response.headers.get("set-cookie", "").lower()  # 전체 소문자 변환
+    # 2. 쿠키 상세 설정 확인
+    set_cookie = response.headers.get("set-cookie", "").lower()
     assert "refresh_token=rt" in set_cookie
-    # 'HttpOnly' 대신 소문자 'httponly'로 검증
     assert "httponly" in set_cookie
     assert "samesite=none" in set_cookie
     assert "secure" in set_cookie
 
-    # 4. 리다이렉트 URL 파라미터 확인
-    location = response.headers.get("location", "")
-    assert "is_new_user=true" in location
-    assert "access_token=at" in location
+    # 3. 바디 데이터 확인 (기존 Location 헤더 검증 제거)
+    data = response.json()
+    assert data["access_token"] == "at"
+    assert data["is_new_user"] is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## ✅ PR 한줄 요약
- 소셜 로그인 콜백 응답을 리다이렉트 방식에서 JSON 바디 응답 방식으로 변경했습니다.

## 🔗 관련 이슈
- Jira: NEAR-136

## 🛠️ 변경 내용
- [x] 응답 타입 변경: RedirectResponse를 JSONResponse로 교체하여 프론트엔드에서 데이터 처리를 용이하게 함

- [x] 토큰 전달 방식 개선:
    * access_token 및 is_new_user 정보를 JSON 응답 바디에 포함
    * 보안을 위해 refresh_token은 HttpOnly 쿠키 방식을 유지
- [x] API 명세: 소셜 콜백 엔드포인트의 리턴 타입을 JSONResponse에 맞춰 수정

## 🧪 테스트
- [x] 로컬 테스트 완료 (`uv run pytest -q`)
- [x] ruff/mypy 통과 확인
  - [x] `uv run ruff check .`
  - [x] `uv run ruff format --check .`
  - [x] `uv run mypy .`

## ⚠️ 리뷰 포인트 / 주의사항
- 프론트엔드에서 기존의 URL 리다이렉트 흐름 대신, API 호출 결과를 받아 처리하는 로직으로의 동기화가 필요합니다.
- JSONResponse 반환 시 쿠키가 정상적으로 브라우저에 저장되는지(SameSite/Secure 설정 등) 다시 한번 확인 부탁드립니다.

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했습니다.
- [x] 불필요한 주석/로그를 제거했습니다.
- [x] 문서/설정 변경이 필요하면 반영했습니다.