### PR TITLE
Near 137 artists admin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,7 @@ jobs:
       S3_RECORDING_BUCKET: ${{ secrets.S3_RECORDING_BUCKET }}
       IMAGES_BUCKET: ${{ secrets.IMAGES_BUCKET }}
       IVS_WEBHOOK_SECRET: ${{ secrets.IVS_WEBHOOK_SECRET }}
+      CLOUDFRONT_DOMAIN: ${{ secrets.CLOUDFRONT_DOMAIN }}
 
       ADMIN_SECRET_KEY: ${{ secrets.ADMIN_SECRET_KEY }}
       ADMIN_USERNAME: admin

--- a/app/admin/resources.py
+++ b/app/admin/resources.py
@@ -4,10 +4,14 @@ from typing import TYPE_CHECKING, Any, cast
 import bcrypt
 from fastadmin import TortoiseModelAdmin as _RuntimeTortoiseModelAdmin
 from fastadmin import display, register
+from fastadmin.settings import settings
 from fastapi import HTTPException
+from tortoise.functions import Count
 
 from app.admin.models import AdminUser
+from app.core.utils.image_resizer import ImageResizer
 from app.domains.artists.models import Artist, Follow
+from app.domains.artists.schemas import ArtistFormSchema
 from app.domains.concerts.models import Concert
 from app.domains.notifications.models import ConcertNoti
 from app.domains.streams.admin.schemas import ChannelConfig, SessionCreateRequest
@@ -40,6 +44,7 @@ if TYPE_CHECKING:
         async def orm_get_obj(self, id: int) -> Any | None: ...
 
         async def serialize_obj(self, obj: Any, list_view: bool = False) -> dict[str, Any]: ...
+
 else:
     TortoiseModelAdmin = _RuntimeTortoiseModelAdmin
 
@@ -145,19 +150,98 @@ class UserDeleteLogAdmin(TortoiseModelAdmin):
 class ArtistAdmin(TortoiseModelAdmin):
     verbose_name = "아티스트"
     verbose_name_plural = _ko_plural(verbose_name)
+
     list_display = (
         "id",
+        "profile_image",
         "stage_name",
+        "agency",
+        "description",
+        "follower_count",
         "category_type",
         "group_type",
-        "debut_date",
         "created_at",
     )
     list_display_links = ("id", "stage_name")
+
+    form_schema = ArtistFormSchema
+
+    fields = (
+        "stage_name",
+        "agency",
+        "description",
+        "profile_img_url",
+        "debut_date",
+        "member_count",
+        "group_type",
+        "category_type",
+        "follower_count",
+    )
+    readonly_fields = ("id", "follower_count", "created_at", "updated_at")
     list_filter = ("category_type", "group_type")
     search_fields = ("stage_name", "agency")
-    search_help_text = "활동명/소속사 검색"
     ordering = ("-created_at",)
+
+    async def get_queryset(self, request: Any) -> Any:
+        return (
+            await cast("_RuntimeTortoiseModelAdmin", super())
+            .get_queryset(request)
+            .annotate(follower_count=Count("followers"))
+        )
+
+    @typed_display
+    def profile_image(self, obj: Artist) -> str:
+        if obj.profile_img_url:
+            cf_domain = getattr(
+                settings, "CLOUDFRONT_DOMAIN", "https://d15qsadcdtxaqn.cloudfront.net"
+            )
+            base_url = cf_domain.rstrip("/")
+            path = obj.profile_img_url.lstrip("/")
+            image_url = f"{base_url}/{path}"
+
+            # HTML이 렌더링되지 않으므로 단순 URL 문자열만 반환합니다.
+            return image_url
+
+        return "-"
+
+    @typed_display
+    def follower_count(self, obj: Any) -> int:
+        return getattr(obj, "follower_count", 0)
+
+    async def save_model(self, id: int | None, payload: dict[str, Any]) -> dict[str, Any] | None:
+        # payload["profile_img_url"]에 파일 객체가 들어옵니다.
+        file_obj = payload.get("profile_img_url")
+
+        if file_obj and not isinstance(file_obj, str):
+            resizer = ImageResizer()
+            target_id = id if id else "new"
+            path_prefix = f"artists/{target_id}/profile/"
+
+            # 기존 파일이 있다면
+            if id:
+                existing_obj = await Artist.get_or_none(id=id)
+                if existing_obj and existing_obj.profile_img_url:
+                    clean_s3_key = existing_obj.profile_img_url
+                    if clean_s3_key.startswith("/images/"):
+                        clean_s3_key = clean_s3_key.replace("/images/", "", 1)
+
+                    await resizer.delete_all_by_id_path(clean_s3_key)
+
+            uploaded_urls = await resizer.upload_square_resizes(
+                image_file=file_obj, sizes=(400,), path_prefix=path_prefix
+            )
+
+            if "400" in uploaded_urls:
+                from urllib.parse import urlparse
+
+                s3_full_url = uploaded_urls["400"]
+                pure_path = urlparse(s3_full_url).path.lstrip("/")
+
+                # 최종 DB 저장 형태: /images/artists/1/profile/image_400.png
+                payload["profile_img_url"] = f"/images/{pure_path}"
+
+        # 파일이 없고 기존 URL 문자열만 있다면 그대로 저장됩니다.
+        return await super().save_model(id, payload)
 
 
 @register(Follow)

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -76,6 +76,7 @@ class Settings(BaseSettings):
     IVS_WEBHOOK_SECRET: str
     ADMIN_IVS_PLAYBACK_TOKEN_EXPIRATION_SEC: int = 600  # 10 min
     IVS_PLAYBACK_TOKEN_EXPIRATION_SEC: int = 3600  # 60 min
+    CLOUDFRONT_DOMAIN: str = "https://d15qsadcdtxaqn.cloudfront.net"
 
     # AWS COGNITO
     COGNITO_CLIENT_ID: str

--- a/app/domains/artists/router.py
+++ b/app/domains/artists/router.py
@@ -1,6 +1,6 @@
 from enum import Enum
 
-from fastapi import APIRouter, Depends, Query, status
+from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile, status
 
 from app.api.deps import get_current_user
 from app.domains.artists.schemas import (
@@ -79,3 +79,30 @@ async def get_artist_recommendations(
 
     # Response 객체로 감싸서 반환
     return ArtistRecommendationResponse(recommended_artists=items)
+
+
+@router.patch(
+    "/{artist_id}/profile-image",
+    summary="아티스트 프로필 이미지 단독 업로드",
+    description="특정 아티스트의 프로필 이미지만 별도로 등록하거나 수정합니다. (슈퍼유저 전용)",
+    status_code=status.HTTP_200_OK,
+)
+async def upload_artist_profile_image(
+    artist_id: int,
+    image_file: UploadFile = File(..., description="업로드할 이미지 파일"),
+    current_user: User = Depends(get_current_user),
+) -> dict[str, str]:
+    """
+    아티스트 프로필 이미지를 업로드하고 업데이트된 경로를 반환합니다.
+    """
+    # 슈퍼유저 권한 체크
+    if not current_user.is_superuser:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="아티스트 이미지를 변경할 권한이 없습니다.",
+        )
+
+    updated_path = await artist_service.update_artist_profile_image(
+        artist_id=artist_id, image_file=image_file
+    )
+    return {"profile_img_url": updated_path}

--- a/app/domains/artists/schemas.py
+++ b/app/domains/artists/schemas.py
@@ -1,5 +1,7 @@
+import datetime
 from datetime import date
 
+from fastapi import UploadFile
 from pydantic import BaseModel, ConfigDict, Field, HttpUrl
 
 from app.domains.artists.models import GroupType
@@ -45,3 +47,18 @@ class ArtistRecommendationElement(ArtistBase):
 
 class ArtistRecommendationResponse(BaseModel):
     recommended_artists: list[ArtistRecommendationElement]
+
+
+class ArtistFormSchema(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    stage_name: str | None = Field(None, title="활동명")
+    agency: str | None = Field(None, title="소속사")
+    description: str | None = Field(None, title="소개")
+    profile_img_url: UploadFile | None = Field(
+        None, title="프로필 이미지", json_schema_extra={"widget": "upload", "form_widget": "upload"}
+    )
+    debut_date: datetime.date | None = Field(None, title="데뷔일")
+    member_count: int | None = Field(0, title="멤버 수")
+    group_type: str | None = Field(None, title="그룹형태")
+    category_type: str | None = Field(None, title="카테고리")

--- a/app/domains/artists/service.py
+++ b/app/domains/artists/service.py
@@ -1,11 +1,14 @@
 import json
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any, cast
+from urllib.parse import urlparse
 
-from fastapi import HTTPException, status
+from fastapi import HTTPException, UploadFile, status
 from tortoise.functions import Count
 
+from app.core.config import settings
 from app.core.redis import redis_client
+from app.core.utils.image_resizer import ImageResizer
 from app.domains.artists.models import Artist, Follow
 from app.domains.artists.schemas import ArtistDetailResponse, ArtistListElement, ArtistListResponse
 
@@ -15,6 +18,23 @@ if TYPE_CHECKING:
 
 
 class ArtistService:
+    def _get_full_image_url(self, path: str | None) -> str:
+        """
+        DB에 저장된 경로를 확인하여 전체 URL을 반환합니다.
+        이미 https://로 시작하면 그대로 반환하고, 아니면 CloudFront 도메인을 붙입니다.
+        """
+        if not path:
+            return ""
+
+        # 이미 전체 URL(https://)이 저장되어 있는 경우 그대로 반환
+        if path.startswith("https://"):
+            return path
+
+        # 상대 경로인 경우 CloudFront 도메인 결합
+        base_url = settings.CLOUDFRONT_DOMAIN.rstrip("/")
+        clean_path = path.lstrip("/")
+        return f"{base_url}/{clean_path}"
+
     async def get_artists(
         self,
         page: int,
@@ -60,7 +80,7 @@ class ArtistService:
             ArtistListElement(
                 id=artist.id,
                 name=artist.stage_name,  # ERD의 stage_name을 그룹명으로 사용
-                profile_image=artist.profile_img_url or "",
+                profile_image=self._get_full_image_url(artist.profile_img_url),
                 company=artist.agency,
                 description=artist.description,
                 follower_count=getattr(artist, "follower_count", 0),
@@ -85,7 +105,7 @@ class ArtistService:
         return ArtistDetailResponse(
             id=artist.id,
             name=artist.stage_name,  #
-            profile_image=artist.profile_img_url,  #
+            profile_image=self._get_full_image_url(artist.profile_img_url),
             company=artist.agency,  #
             description=artist.description,  #
             category=artist.category_type,  #
@@ -162,7 +182,7 @@ class ArtistService:
             {
                 "id": recs.id,
                 "name": recs.stage_name,
-                "profile_image": recs.profile_img_url or "",
+                "profile_image": self._get_full_image_url(recs.profile_img_url),
                 "company": recs.agency or "",
                 "follower_count": getattr(recs, "follower_count", 0),
                 "recommendation_reason": reason,
@@ -202,6 +222,51 @@ class ArtistService:
             )
 
         return result
+
+    async def update_artist_profile_image(self, artist_id: int, image_file: UploadFile) -> str:
+        """
+        특정 아티스트의 프로필 이미지를 업로드하고 경로를 업데이트합니다.
+        """
+        artist = await Artist.get_or_none(id=artist_id)
+        if not artist:
+            raise HTTPException(status_code=404, detail="아티스트를 찾을 수 없습니다.")
+
+        resizer = ImageResizer()
+        path_prefix = f"artists/{artist_id}/profile/"
+
+        # 기존 이미지가 있다면 S3에서 삭제
+        if artist.profile_img_url:
+            clean_s3_key = artist.profile_img_url
+            # 상대 경로(/images/...)인 경우 프리픽스 제거 후 삭제
+            if clean_s3_key.startswith("/images/"):
+                clean_s3_key = clean_s3_key.replace("/images/", "", 1)
+            # 전체 URL(https://...)인 경우 S3 키만 추출하여 삭제
+            elif clean_s3_key.startswith("https://"):
+                clean_s3_key = urlparse(clean_s3_key).path.lstrip("/")
+                # 만약 전체 URL 경로에도 /images/가 포함되어 있다면 제거
+                if clean_s3_key.startswith("images/"):
+                    clean_s3_key = clean_s3_key.replace("images/", "", 1)
+
+            await resizer.delete_all_by_id_path(clean_s3_key)
+
+        # 새 이미지 리사이징 및 업로드 (400px 기준)
+        uploaded_urls = await resizer.upload_square_resizes(
+            image_file=image_file.file, sizes=(400,), path_prefix=path_prefix
+        )
+
+        if "400" not in uploaded_urls:
+            raise HTTPException(status_code=500, detail="이미지 업로드에 실패했습니다.")
+
+        # DB 저장용 경로 생성 (/images/ 프리픽스 추가)
+        s3_url = uploaded_urls["400"]
+        pure_path = urlparse(s3_url).path.lstrip("/")
+        db_path = f"/images/{pure_path}"
+
+        # DB 업데이트
+        artist.profile_img_url = db_path
+        await artist.save(update_fields=["profile_img_url"])
+
+        return self._get_full_image_url(db_path)
 
 
 artist_service = ArtistService()


### PR DESCRIPTION
✅ PR 한줄 요약
* 어드민 전용 아티스트 관리 API 구현 및 슈퍼유저 권한을 적용한 프로필 이미지 업로드 로직을 완성했습니다. 

🔗 관련 이슈
* Jira: NEAR-137 

🛠️ 변경 내용
* [x] 아티스트 관리 엔드포인트 구현: router.py, service.py를 통해 아티스트 프로필 이미지 업로드 및 관리 기능 완성
* [x] 슈퍼유저 권한 체크 강화: is_superuser 로직을 추가하여 어드민 전용 기능에 대한 보안 레이어 적용
* [x] 어드민 리소스 확장: ArtistAdmin 클래스 구현으로 아티스트 CRUD(생성/조회/수정/삭제) 대
* [x] S3 및 이미지 처리 로직 최적화: 이미지 리사이징, S3 자동 업로드 및 기존 이미지 교체 시 이전 파일 자동 삭제 기능 포함
* [x] 인프라 설정 반영: CloudFront 서빙을 위한 CLOUDFRONT_DOMAIN 설정 추가 및 CI 환경 변수 업데이트 

🧪 테스트
* [x] 로컬 테스트 완료 (uv run pytest -q)
* [x] ruff/mypy 통과 확인
    * [x] uv run ruff check .
    * [x] uv run ruff format --check .
    * [x] uv run mypy . 

⚠️ 리뷰 포인트 / 주의사항
* 권한 체크: router.py에서 is_superuser 필터를 통해 일반 유저의 접근이 확실히 차단되는지 검토 부탁드립니다.

* S3 삭제 로직: 이미지 교체 시 기존 파일을 삭제하는 로직이 예외 상황(이미 파일이 없는 경우 등)에서도 안전하게 동작하는지 확인이 필요합니다.
* CloudFront 설정: config.py에 추가된 도메인 값이 실제 서빙 환경과 일치하는지 체크해 주세요. CLOUDFRONT_DOMAIN=https://d15qsadcdtxaqn.cloudfront.net
<img width="1446" height="903" alt="스크린샷 2026-02-08 오후 9 04 47" src="https://github.com/user-attachments/assets/be7ae790-b48d-4395-a5e1-59b5968f4061" />
<img width="1443" height="608" alt="스크린샷 2026-02-08 오후 9 04 42" src="https://github.com/user-attachments/assets/0c72cf44-13e7-47ea-a56d-2435f4be083d" />

✅ 체크리스트
* [x] 커밋 메시지 컨벤션을 준수했습니다.
* [x] 불필요한 주석/로그를 제거했습니다.
* [x] 문서/설정 변경이 필요하면 반영했습니다.