### PR TITLE
[NEAR-134] Feat: AWS Lambda Web Adapter 설정 추가 및 헬스체크 환경 변수 설정

### DIFF
--- a/docker/Dockerfile.prod
+++ b/docker/Dockerfile.prod
@@ -1,5 +1,8 @@
 FROM python:3.13-slim
 
+# AWS Lambda Web Adapter 추가
+COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:0.9.1 /lambda-adapter /opt/extensions/lambda-adapter
+
 # 빌드/런타임에 필요한 시스템 패키지
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
@@ -20,6 +23,9 @@ RUN uv sync --locked --no-dev --no-install-project
 # 소스 복사
 COPY . .
 
+# Lambda 환경을 위한 Readiness Check 및 포트 설정
+ENV PORT=8000
+ENV AWS_LWA_READINESS_CHECK_PATH=/health
 EXPOSE 8000
 
 CMD ["uv", "run", "uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
* Docker 이미지를 빌드할 때 Lambda용 어댑터 레이어를 추가하는 것으로, 기존 EC2 배포 및 Celery 워커 동작에는 영향을 주지 않습니다.

✅ PR 한줄 요약
* API 서버의 서버리스(Lambda) 전환을 위해 AWS Lambda Web Adapter 설정을 추가하고 헬스체크 경로를 구성했습니다.

🔗 관련 이슈
* Jira: NEAR-134

🛠️ 변경 내용
- [x] Dockerfile.prod에 AWS Lambda Web Adapter 바이너리 복사 레이어 추가
- [x] Lambda 환경의 준비 상태 확인을 위한 AWS_LWA_READINESS_CHECK_PATH 환경 변수 설정
- [x] Lambda 실행 포트(PORT=8000) 환경 변수 명시

🧪 테스트
[x] 로컬 테스트 완료 (uv run pytest -q)
[x] ruff/mypy 통과 확인
[x] uv run ruff check .
[x] uv run ruff format --check .
[x] uv run mypy .

⚠️ 리뷰 포인트 / 주의사항
- 영향 범위: 이번 변경은 Docker 이미지를 빌드할 때 Lambda용 어댑터 레이어를 추가하는 것으로, 기존 EC2 배포 및 Celery 워커 동작에는 영향을 주지 않습니다.

✅ 체크리스트
[x] 커밋 메시지 컨벤션을 준수했습니다.
[x] 불필요한 주석/로그를 제거했습니다.
[x] 문서/설정 변경이 필요하면 반영했습니다.