### PR TITLE
[NEAR-141] Refactor: Dockerfile.prod 내 uvicorn 직접 실행으로 변경

### DIFF
--- a/docker/Dockerfile.prod
+++ b/docker/Dockerfile.prod
@@ -26,6 +26,11 @@ COPY . .
 # Lambda 환경을 위한 Readiness Check 및 포트 설정
 ENV PORT=8000
 ENV AWS_LWA_READINESS_CHECK_PATH=/health
+# uv가 런타임에 작동하지 못하도록 환경 변수 고정
+ENV UV_NO_SYNC=true
+ENV UV_PROJECT_ENVIRONMENT=/usr/local
+
 EXPOSE 8000
 
-CMD ["uv", "run", "uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+# uv run 대신 uvicorn을 직접 호출
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## ✅ PR 한줄 요약
- 람다 환경에서 'uv run' 시 발생하는 빌드 지연 및 권한 에러 해결

## 🔗 관련 이슈
- Jira: NEAR-141


## 🛠️ 변경 내용
- [x] EC2 환경은 docker-compose.prod.yml에서 이미지를 불러와 독립적으로 실행되므로, Dockerfile.prod 자체를 람다에 최적화된 방식으로 수정해도 EC2 서비스에는 영향이 없습니다.

    수정전
    
    CMD ["uv", "run", "uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
    
    수정후
    
    CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
