### PR TITLE
[NEAR-144] Fix: RDS 연결 시 SSL 인증서 검증 오류 수정

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -96,7 +96,7 @@ class Settings(BaseSettings):
     @computed_field  # type: ignore[prop-decorator]
     @property
     def DATABASE_URL(self) -> str:
-        return f"{self.DB_SCHEME}://{self.DB_USER}:{self.DB_PASSWORD}@{self.DB_HOST}:{self.DB_PORT}/{self.DB_NAME}"
+        return f"{self.DB_SCHEME}://{self.DB_USER}:{self.DB_PASSWORD}@{self.DB_HOST}:{self.DB_PORT}/{self.DB_NAME}?ssl=insecure"
 
     @computed_field  # type: ignore[prop-decorator]
     @property


### PR DESCRIPTION
## ✅ PR 한줄 요약
- SSLCertVerificationError로 인해 API 500 에러 발생하는 문제 해결.

## 🔗 관련 이슈
- Jira: NEAR-144

## 🛠️ 변경 내용
- [ ] DATABASE_URL에 ssl=insecure 파라미터 추가. 
- [ ] SSLCertVerificationError로 인해 API 500 에러 발생하는 문제 해결.
- [ ] sslrootcert=path/to/ca-bundle.pem 형식으로의 변경 필요.
