### PR TITLE
[NEAR-144] Fix: DB 호스트 주소에 따른 선택적 SSL 적용

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -96,7 +96,12 @@ class Settings(BaseSettings):
     @computed_field  # type: ignore[prop-decorator]
     @property
     def DATABASE_URL(self) -> str:
-        return f"{self.DB_SCHEME}://{self.DB_USER}:{self.DB_PASSWORD}@{self.DB_HOST}:{self.DB_PORT}/{self.DB_NAME}?ssl=insecure"
+        url = f"{self.DB_SCHEME}://{self.DB_USER}:{self.DB_PASSWORD}@{self.DB_HOST}:{self.DB_PORT}/{self.DB_NAME}"
+
+        # DB_HOST 주소에 'amazonaws.com'이 포함되어 있다면 (즉, RDS라면) SSL 옵션 추가
+        if "amazonaws.com" in self.DB_HOST:
+            url += "?ssl=insecure"
+        return url
 
     @computed_field  # type: ignore[prop-decorator]
     @property


### PR DESCRIPTION
## ✅ PR 한줄 요약
- DB_HOST가 RDS(amazonaws.com)인 경우에만 ?ssl=insecure 옵션 추가.

## 🔗 관련 이슈
- Jira: NEAR-144

## 🛠️ 변경 내용
- [ ] DB_HOST가 RDS(amazonaws.com)인 경우에만 ?ssl=insecure 옵션 추가.
- [ ] GitHub Actions 배포 과정에서 Docker 내부 DB 연결 시 rejected SSL upgrade 에러가 발생하는 문제 해결.
- [ ] 환경(Lambda vs Docker) 간의 DB 연결 설정 호환성 확보.
