### PR TITLE
[NEAR-147] Refactor: Use relative path with /images prefix for profil…

### DIFF
--- a/app/domains/users/service.py
+++ b/app/domains/users/service.py
@@ -1,5 +1,6 @@
 from datetime import UTC, datetime
 from typing import cast
+from urllib.parse import urlparse
 
 import boto3
 from fastapi import HTTPException, Response, UploadFile, status
@@ -131,8 +132,12 @@ class UserService:
         )
 
         # DB 업데이트 (예: 중간 사이즈인 300px을 기본 URL로 저장)
-        img_url = urls.get("300")
-        user.profile_img_url = img_url if img_url else ""
+        img_url_300 = urls.get("300")
+        if img_url_300:
+            pure_path = urlparse(img_url_300).path.lstrip("/")
+            user.profile_img_url = f"/images/{pure_path}"
+        else:
+            user.profile_img_url = ""
 
         return user
 

--- a/tests/users/test_service.py
+++ b/tests/users/test_service.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from botocore.exceptions import ClientError
 from fastapi import HTTPException
+from PIL import Image
 
 from app.domains.artists.models import Artist
 from app.domains.concerts.models import CategoryType
@@ -81,8 +82,6 @@ async def test_image_resizer_and_s3_error_cases(initialize_tests):
 async def test_update_profile_image_coverage(initialize_tests):
     user = await User.create(nickname="img_test", provider=ProviderChoice.KAKAO, provider_id="p123")
 
-    from PIL import Image
-
     img = Image.new("RGB", (10, 10), color="red")
     img_byte_arr = io.BytesIO()
     img.save(img_byte_arr, format="PNG")
@@ -95,16 +94,23 @@ async def test_update_profile_image_coverage(initialize_tests):
 
     with (
         patch(
-            "app.integrations.s3_client.S3Client.upload_with_key", new_callable=AsyncMock
-        ) as mock_s3_upload,
-        patch("app.integrations.s3_client.S3Client.build_url") as mock_build_url,
+            "app.core.utils.image_resizer.ImageResizer.upload_square_resizes",
+            new_callable=AsyncMock,
+        ) as mock_upload,
     ):
-        mock_s3_upload.return_value = "users/1/profile/profile200.png"
-        mock_build_url.return_value = "http://s3.url/200.png"
+        # 1. ImageResizer가 반환하는 가상의 S3 Full URL 설정
+        mock_upload.return_value = {
+            "300": "https://near-images.s3.ap-northeast-2.amazonaws.com/users/1/profile/image_300.png"
+        }
 
+        # 2. 서비스 함수 호출
         await user_service.update_profile_image(user, mock_file)
+
+        # 3. DB 확인
         await user.refresh_from_db()
-        assert user.profile_img_url == "http://s3.url/200.png"
+
+        # [검증 포인트] DB에는 도메인이 제거되고 /images/ 프리픽스가 붙은 경로가 저장되어야 함
+        assert user.profile_img_url == "/images/users/1/profile/image_300.png"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## ✅ PR 한줄 요약
- 유저프로필 저장할  떄 s3 저장할떄의 url 저장함에 수정

## 🔗 관련 이슈
- Jira: NEAR-147

## 🛠️ 변경 내용
- [x] * _update_profile에서 S3 Full URL 대신 /images/ 상대 경로를 저장하도록 수정
- [x]  urlparse를 사용하여 도메인을 제거하고 순수 S3 Key만 추출하도록 로직 개선

## 🧪 테스트
- [x] 로컬 테스트 완료 (`uv run pytest -q`)
- [x] ruff/mypy 통과 확인
  - [x] `uv run ruff check .`
  - [x] `uv run ruff format --check .`
  - [x] `uv run mypy .`

## ⚠️ 리뷰 포인트 / 주의사항
- 엉엉